### PR TITLE
webinar: Allow passcodes

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -195,7 +195,6 @@ class mod_zoom_mod_form extends moodleform_mod {
         $regex = '/^[a-zA-Z0-9@_*-]{1,10}$/';
         $mform->addRule('meetingcode', get_string('err_invalid_password', 'mod_zoom'), 'regex', $regex, 'client');
         $mform->setDefault('meetingcode', strval(rand(100000, 999999)));
-        $mform->disabledIf('meetingcode', 'webinar', 'checked');
         $mform->addRule('meetingcode', null, 'required', null, 'client');
         $mform->addElement('static', 'passwordrequirements', '', get_string('err_password', 'mod_zoom'));
 

--- a/templates/mobile_view_page.mustache
+++ b/templates/mobile_view_page.mustache
@@ -32,13 +32,11 @@
 			</ion-item>
 		<%/zoom.recurring%>
 		
-		<%^zoom.webinar%>
-			<ion-item>
-				<p class="item-heading">{{ 'plugin.mod_zoom.passwordprotected' | translate }}</p>
-				<%#zoom.password%><p>{{ 'core.yes' | translate }}</p><%/zoom.password%>
-				<%^zoom.password%><p>{{ 'core.no' | translate }}</p><%/zoom.password%>
-			</ion-item>
-		<%/zoom.webinar%>
+		<ion-item>
+			<p class="item-heading">{{ 'plugin.mod_zoom.passwordprotected' | translate }}</p>
+			<%#zoom.password%><p>{{ 'core.yes' | translate }}</p><%/zoom.password%>
+			<%^zoom.password%><p>{{ 'core.no' | translate }}</p><%/zoom.password%>
+		</ion-item>
 	  
 		<%^zoom.webinar%>
 			<ion-item>

--- a/view.php
+++ b/view.php
@@ -169,14 +169,12 @@ if ($zoom->recurring) {
     $table->data[] = array($strduration, format_time($zoom->duration));
 }
 
-if (!$zoom->webinar) {
-    $haspassword = (isset($zoom->password) && $zoom->password !== '');
-    $strhaspass = ($haspassword) ? $stryes : $strno;
-    $table->data[] = array($strpassprotect, $strhaspass);
+$haspassword = (isset($zoom->password) && $zoom->password !== '');
+$strhaspass = ($haspassword) ? $stryes : $strno;
+$table->data[] = array($strpassprotect, $strhaspass);
 
-    if ($userishost && $haspassword) {
-        $table->data[] = array($strpassword, $zoom->password);
-    }
+if ($userishost && $haspassword) {
+    $table->data[] = array($strpassword, $zoom->password);
 }
 
 if ($userishost) {


### PR DESCRIPTION
I believe these are the only barriers, but it would be good to have someone with a webinar confirm.

Side note: With the rebranding of "passwords" to "passcodes", should we update the two affected language strings?

Fixes #107 