### PR TITLE
Feature/ccle 9588 invite note on ical

### DIFF
--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -582,6 +582,24 @@ class mod_zoom_webservice {
     }
 
     /**
+     * Get the meeting invite note that was sent for a specific meeting from Zoom.
+     *
+     * @param int $id The meeting_id of the meeting to retrieve.
+     * @return stdClass The meeting's invite note.
+     * @link 
+     */
+    public function get_meeting_invitation($id) {
+        $url = 'meetings/' . $id . '/invitation';
+        $response = null;
+        try {
+            $response = $this->_make_call($url);
+        } catch (moodle_exception $error) {
+            throw $error;
+        }
+        return $response;
+    }
+
+    /**
      * Retrieve ended meetings report for a specified user and period. Handles multiple pages.
      *
      * @param int $userid Id of user of interest

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -576,7 +576,7 @@ class mod_zoom_webservice {
         try {
             $response = $this->_make_call($url);
         } catch (moodle_exception $error) {
-            throw $error;
+            debugging($error->getMessage());
         }
         return $response;
     }

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -586,7 +586,7 @@ class mod_zoom_webservice {
      *
      * @param int $id The meeting_id of the meeting to retrieve.
      * @return stdClass The meeting's invite note.
-     * @link 
+     * @link https://marketplace.zoom.us/docs/api-reference/zoom-api/meetings/meetinginvitation
      */
     public function get_meeting_invitation($id) {
         $url = 'meetings/' . $id . '/invitation';

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -576,7 +576,7 @@ class mod_zoom_webservice {
         try {
             $response = $this->_make_call($url);
         } catch (moodle_exception $error) {
-            debugging($error->getMessage());
+            throw $error;
         }
         return $response;
     }
@@ -594,7 +594,7 @@ class mod_zoom_webservice {
         try {
             $response = $this->_make_call($url);
         } catch (moodle_exception $error) {
-            throw $error;
+            debugging($error->getMessage());
         }
         return $response;
     }

--- a/exportical.php
+++ b/exportical.php
@@ -63,7 +63,7 @@ $event->add_property('dtend', Bennu::timestamp_to_datetime($zoom->start_time + $
 // Get the meeting invite note to add to the description property.
 $service = new mod_zoom_webservice();
 $response = $service->get_meeting_invitation($zoom->meeting_id);
-$meeting_invite = $response->invitation;
+$meetinginvite = $response->invitation;
 
 // Compute and add description property to event.
 $convertedtext = html_to_text($zoom->intro);
@@ -71,7 +71,7 @@ $descriptiontext = get_string('calendardescriptionURL', 'mod_zoom', $CFG->wwwroo
 if (!empty($convertedtext)) {
     $descriptiontext .= get_string('calendardescriptionintro', 'mod_zoom', $convertedtext);
 }
-$descriptiontext .= PHP_EOL . $meeting_invite;
+$descriptiontext .= PHP_EOL . $meetinginvite;
 $event->add_property('description', $descriptiontext);
 
 // Start formatting ical.

--- a/exportical.php
+++ b/exportical.php
@@ -60,12 +60,18 @@ $event->add_property('last-modified', Bennu::timestamp_to_datetime($zoom->timemo
 $event->add_property('dtstart', Bennu::timestamp_to_datetime($zoom->start_time)); // Start time.
 $event->add_property('dtend', Bennu::timestamp_to_datetime($zoom->start_time + $zoom->duration)); // End time.
 
+// Get the meeting invite note to add to the description property.
+$service = new mod_zoom_webservice();
+$response = $service->get_meeting_invitation($zoom->meeting_id);
+$meeting_invite = $response->invitation;
+
 // Compute and add description property to event.
 $convertedtext = html_to_text($zoom->intro);
 $descriptiontext = get_string('calendardescriptionURL', 'mod_zoom', $CFG->wwwroot . '/mod/zoom/view.php?id=' . $cm->id);
 if (!empty($convertedtext)) {
     $descriptiontext .= get_string('calendardescriptionintro', 'mod_zoom', $convertedtext);
 }
+$descriptiontext .= PHP_EOL . $meeting_invite;
 $event->add_property('description', $descriptiontext);
 
 // Start formatting ical.

--- a/exportical.php
+++ b/exportical.php
@@ -71,7 +71,9 @@ $descriptiontext = get_string('calendardescriptionURL', 'mod_zoom', $CFG->wwwroo
 if (!empty($convertedtext)) {
     $descriptiontext .= get_string('calendardescriptionintro', 'mod_zoom', $convertedtext);
 }
-$descriptiontext .= PHP_EOL . $meetinginvite;
+if (!empty($meetinginvite)) {
+    $descriptiontext .= "\n\n" . $meetinginvite;
+}
 $event->add_property('description', $descriptiontext);
 
 // Start formatting ical.


### PR DESCRIPTION
The Zoom meeting invitation text is added to the iCal description export. This includes the Zoom meeting link and the call-in information.

<img width="274" alt="Screen Shot 2020-11-23 at 12 22 08 PM" src="https://user-images.githubusercontent.com/17104896/100014230-f3907700-2d8a-11eb-853a-03cf5cb8af26.png">

