### PR TITLE
exists_on_zoom: Update during recreate and meeting-not-found

### DIFF
--- a/recreate.php
+++ b/recreate.php
@@ -46,6 +46,8 @@ $service = new mod_zoom_webservice();
 // Set the current zoom table entry to use the new meeting (meeting_id/etc).
 $response = $service->create_meeting($zoom);
 $zoom = populate_zoom_from_response($zoom, $response);
+$zoom->exists_on_zoom = ZOOM_MEETING_EXISTS;
+$zoom->timemodified = time();
 $DB->update_record('zoom', $zoom);
 
 // Return to Zoom page.


### PR DESCRIPTION
 - On recreate, set ZOOM_MEETING_EXISTS and update the time.
 - On view, if we already know it's expired, show the recreate message.
 - On view, if the API lets us know that the meeting no longer exists, mark as ZOOM_MEETING_EXPIRED.

Fixes #271
Fixes #272 

Note: In #272, @abias mentions the update_meetings task. The only meetings that are processed are the ones that are already set to ZOOM_MEETING_EXISTS, so we should not need to set ZOOM_MEETING_EXISTS.