### PR TITLE
ci: currently Moodle needs mariadb < 10.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           - 5432:5432
 
       mariadb:
-        image: mariadb
+        image: mariadb:10.5
         env:
           MYSQL_USER: 'root'
           MYSQL_ALLOW_EMPTY_PASSWORD: "true"


### PR DESCRIPTION
Reference: https://github.com/moodlehq/moodle-plugin-ci/pull/115