### PR TITLE
Fix/289 zoom intro

### DIFF
--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -507,7 +507,7 @@ class mod_zoom_webservice {
             )
         );
         if (isset($zoom->intro)) {
-            $data['agenda'] = $zoom->intro;
+            $data['agenda'] = content_to_text($zoom->intro, FORMAT_MOODLE);
         }
         if (isset($CFG->timezone) && !empty($CFG->timezone)) {
             $data['timezone'] = $CFG->timezone;

--- a/lib.php
+++ b/lib.php
@@ -190,9 +190,6 @@ function populate_zoom_from_response(stdClass $zoom, stdClass $response) {
     }
     $newzoom->meeting_id = $response->id;
     $newzoom->name = $response->topic;
-    if (isset($response->agenda)) {
-        $newzoom->intro = $response->agenda;
-    }
     if (isset($response->start_time)) {
         $newzoom->start_time = strtotime($response->start_time);
     }


### PR DESCRIPTION
The proposal is to not update the Moodle intro when Zoom sends a response. Zoom removes any special characters and styling breaking the Moodle intro created by the instructor. And also, to send Zoom a more friendly agenda.

Fix #289 
Fix #190 
Fix #196 