### PR TITLE
Mobile app patch

### DIFF
--- a/classes/external.php
+++ b/classes/external.php
@@ -228,7 +228,6 @@ class mod_zoom_external extends external_api {
         \mod_zoom\event\join_meeting_button_clicked::create(array('context' => $context, 'objectid' => $zoom->id, 'other' =>
             array('cmid' => (int) $cm->id, 'meetingid' => (int) $zoom->meeting_id, 'userishost' => $userishost)))->trigger();
 
-
         // Pass url to join zoom meeting in order to redirect user.
         $result = array();
         $result['status'] = true;

--- a/classes/external.php
+++ b/classes/external.php
@@ -197,7 +197,8 @@ class mod_zoom_external extends external_api {
         $userishost = (zoom_get_user_id(false) == $zoom->host_id);
 
         if ($userishost) {
-            $joinurl = new moodle_url($zoom->start_url, array('uname' => fullname($USER)));
+            // Start URL will not launch Zoom app, so using join url instead.
+            $joinurl = new moodle_url($zoom->join_url, array('uname' => fullname($USER)));
         } else {
             // Check whether user had a grade. If no, then assign full credits to him or her.
             $gradelist = grade_get_grades($course->id, 'mod', 'zoom', $cm->instance, $USER->id);


### PR DESCRIPTION
This addresses issue #304 

I added a host check as well because it is used by the event. However, in testing, I noticed that the start url does not automatically redirect to Zoom's mobile app like the join url does, so I reverted to using the join url for both hosts and participants. I left the two separate in case Zoom modifies the start url behavior in the future so we can more easily make use of it.