### PR TITLE
load meeting function

### DIFF
--- a/classes/external.php
+++ b/classes/external.php
@@ -174,12 +174,14 @@ class mod_zoom_external extends external_api {
      */
     public static function grade_item_update($zoomid) {
         global $CFG;
-        require_once($CFG->dirroot . "/mod/zoom/locallib.php");
+        require_once($CFG->dirroot . '/mod/zoom/locallib.php');
 
-        $params = self::validate_parameters(self::get_state_parameters(),
-                                            array(
-                                                'zoomid' => $zoomid
-                                            ));
+        $params = self::validate_parameters(
+            self::get_state_parameters(),
+            array(
+                'zoomid' => $zoomid,
+            )
+        );
         $warnings = array();
 
         $context = context_module::instance($params['zoomid']);

--- a/classes/external.php
+++ b/classes/external.php
@@ -194,7 +194,7 @@ class mod_zoom_external extends external_api {
             $result['status'] = true;
             $result['joinurl'] = $meetinginfo['nexturl']->__toString();
         } else {
-            $warningmsg = clean_param($meetinginfo['error'],PARAM_TEXT);
+            $warningmsg = clean_param($meetinginfo['error'], PARAM_TEXT);
             throw new invalid_response_exception($warningmsg);
         }
         $result['warnings'] = $warnings;

--- a/classes/external.php
+++ b/classes/external.php
@@ -194,8 +194,8 @@ class mod_zoom_external extends external_api {
             $result['status'] = true;
             $result['joinurl'] = $meetinginfo['nexturl']->__toString();
         } else {
-            $result['status'] = false;
-            $result['joinurl'] = '';
+            $warningmsg = clean_param($meetinginfo['error'],PARAM_TEXT);
+            throw new invalid_response_exception($warningmsg);
         }
         $result['warnings'] = $warnings;
         return $result;

--- a/loadmeeting.php
+++ b/loadmeeting.php
@@ -22,8 +22,8 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once(dirname(dirname(dirname(__FILE__))).'/config.php');
-require_once(dirname(__FILE__).'/locallib.php');
+require_once(dirname(dirname(__DIR__)) . '/config.php');
+require_once(__DIR__ . '/locallib.php');
 
 // Course_module ID.
 $id = required_param('id', PARAM_INT);

--- a/loadmeeting.php
+++ b/loadmeeting.php
@@ -15,10 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Load zoom meeting and assign grade to the user join the meeting.
- *
- * You can have a rather longer description of the file as well,
- * if you like, and it can span multiple lines.
+ * Load zoom meeting.
  *
  * @package    mod_zoom
  * @copyright  2015 UC Regents
@@ -26,83 +23,27 @@
  */
 
 require_once(dirname(dirname(dirname(__FILE__))).'/config.php');
-require_once($CFG->libdir . '/gradelib.php');
-require_once($CFG->libdir . '/moodlelib.php');
 require_once(dirname(__FILE__).'/locallib.php');
 
 // Course_module ID.
 $id = required_param('id', PARAM_INT);
 if ($id) {
-    $cm         = get_coursemodule_from_id('zoom', $id, 0, false, MUST_EXIST);
-    $course     = get_course($cm->course);
-    $zoom  = $DB->get_record('zoom', array('id' => $cm->instance), '*', MUST_EXIST);
+    $context = context_module::instance($id);
+    $PAGE->set_context($context);
+
+    // Call load meeting function.
+    $meetinginfo = zoom_load_meeting($id, $context);
+	
+    // Redirect if available, otherwise deny access.
+    if ($meetinginfo['nexturl']) {
+        redirect($meetinginfo['nexturl']);
+    } else {
+        // Get redirect URL.
+        $unavailabilityurl = new moodle_url('/mod/zoom/view.php', array('id' => $id));
+
+        // Redirect the user back to the activity overview page.
+        redirect($unavailabilityurl, $meetinginfo['error'], null, \core\output\notification::NOTIFY_ERROR);
+    }
 } else {
     print_error('You must specify a course_module ID');
 }
-$userisrealhost = (zoom_get_user_id(false) === $zoom->host_id);
-$alternativehosts = zoom_get_alternative_host_array_from_string($zoom->alternative_hosts);
-$userishost = ($userisrealhost || in_array(zoom_get_api_identifier($USER), $alternativehosts, true));
-
-require_login($course, true, $cm);
-
-$context = context_module::instance($cm->id);
-$PAGE->set_context($context);
-
-require_capability('mod/zoom:view', $context);
-
-// Get meeting state from Zoom.
-list($inprogress, $available, $finished) = zoom_get_state($zoom);
-
-// If the meeting is not yet available, deny access.
-if ($available !== true) {
-    // Get unavailability note.
-    $unavailabilitynote = zoom_get_unavailability_note($zoom, $finished);
-
-    // Get redirect URL.
-    $unavailabilityurl = new moodle_url('/mod/zoom/view.php', array('id' => $id));
-
-    // Redirect the user back to the activity overview page.
-    redirect($unavailabilityurl, $unavailabilitynote, null, \core\output\notification::NOTIFY_ERROR);
-}
-
-if ($userisrealhost) {
-    // Important: Only the real host can use this URL, because it joins the meeting as the host user.
-    $nexturl = new moodle_url($zoom->start_url);
-} else {
-    // Check whether user had a grade. If no, then assign full credits to him or her.
-    $gradelist = grade_get_grades($course->id, 'mod', 'zoom', $cm->instance, $USER->id);
-
-    // Assign full credits for user who has no grade yet, if this meeting is gradable (i.e. the grade type is not "None").
-    if (!empty($gradelist->items) && empty($gradelist->items[0]->grades[$USER->id]->grade)) {
-        $grademax = $gradelist->items[0]->grademax;
-        $grades = array('rawgrade' => $grademax,
-                        'userid' => $USER->id,
-                        'usermodified' => $USER->id,
-                        'dategraded' => '',
-                        'feedbackformat' => '',
-                        'feedback' => '');
-
-        zoom_grade_item_update($zoom, $grades);
-    }
-
-    $nexturl = new moodle_url($zoom->join_url, array('uname' => fullname($USER)));
-}
-
-// Track completion viewed.
-$completion = new completion_info($course);
-$completion->set_module_viewed($cm);
-
-// Record user's clicking join.
-\mod_zoom\event\join_meeting_button_clicked::create(array('context' => $context, 'objectid' => $zoom->id, 'other' =>
-        array('cmid' => $id, 'meetingid' => (int) $zoom->meeting_id, 'userishost' => $userishost)))->trigger();
-
-// Upgrade host upon joining meeting, if host if not Licensed.
-if ($userishost) {
-    $config = get_config('zoom');
-    if (!empty($config->recycleonjoin)) {
-        $service = new mod_zoom_webservice();
-        $service->provide_license($zoom->host_id);
-    }
-}
-
-redirect($nexturl);

--- a/loadmeeting.php
+++ b/loadmeeting.php
@@ -33,7 +33,7 @@ if ($id) {
 
     // Call load meeting function.
     $meetinginfo = zoom_load_meeting($id, $context);
-	
+
     // Redirect if available, otherwise deny access.
     if ($meetinginfo['nexturl']) {
         redirect($meetinginfo['nexturl']);

--- a/locallib.php
+++ b/locallib.php
@@ -1020,7 +1020,7 @@ function zoom_get_api_url() {
 }
 
 /**
- * Loads the zoom meeting and passes back a meeting url
+ * Loads the zoom meeting and passes back a meeting URL
  * after processing events, view completion, grades, and license updates.
  *
  * @param int $id course module id
@@ -1032,9 +1032,9 @@ function zoom_load_meeting($id, $context, $usestarturl = true) {
     global $CFG, $DB, $USER;
     require_once($CFG->libdir . '/gradelib.php');
 
-    $cm         = get_coursemodule_from_id('zoom', $id, 0, false, MUST_EXIST);
-    $course     = get_course($cm->course);
-    $zoom  = $DB->get_record('zoom', array('id' => $cm->instance), '*', MUST_EXIST);
+    $cm = get_coursemodule_from_id('zoom', $id, 0, false, MUST_EXIST);
+    $course = get_course($cm->course);
+    $zoom = $DB->get_record('zoom', array('id' => $cm->instance), '*', MUST_EXIST);
 
     require_login($course, true, $cm);
 
@@ -1064,30 +1064,39 @@ function zoom_load_meeting($id, $context, $usestarturl = true) {
     }
 
     // Record user's clicking join.
-    \mod_zoom\event\join_meeting_button_clicked::create(array('context' => $context, 'objectid' => $zoom->id, 'other' =>
-            array('cmid' => $id, 'meetingid' => (int) $zoom->meeting_id, 'userishost' => $userishost)))->trigger();
+    \mod_zoom\event\join_meeting_button_clicked::create(array(
+        'context' => $context,
+        'objectid' => $zoom->id,
+        'other' => array(
+            'cmid' => $id,
+            'meetingid' => (int) $zoom->meeting_id,
+            'userishost' => $userishost,
+        ),
+    ))->trigger();
 
     // Track completion viewed.
     $completion = new completion_info($course);
     $completion->set_module_viewed($cm);
 
-    // Check whether user had a grade. If no, then assign full credits to him or her.
+    // Check whether user has a grade. If not, then assign full credit to them.
     $gradelist = grade_get_grades($course->id, 'mod', 'zoom', $cm->instance, $USER->id);
 
     // Assign full credits for user who has no grade yet, if this meeting is gradable (i.e. the grade type is not "None").
     if (!empty($gradelist->items) && empty($gradelist->items[0]->grades[$USER->id]->grade)) {
         $grademax = $gradelist->items[0]->grademax;
-        $grades = array('rawgrade' => $grademax,
-                        'userid' => $USER->id,
-                        'usermodified' => $USER->id,
-                        'dategraded' => '',
-                        'feedbackformat' => '',
-                        'feedback' => '');
+        $grades = array(
+            'rawgrade' => $grademax,
+            'userid' => $USER->id,
+            'usermodified' => $USER->id,
+            'dategraded' => '',
+            'feedbackformat' => '',
+            'feedback' => '',
+        );
 
         zoom_grade_item_update($zoom, $grades);
     }
 
-    // Upgrade host upon joining meeting, if host if not Licensed.
+    // Upgrade host upon joining meeting, if host is not Licensed.
     if ($userishost) {
         $config = get_config('zoom');
         if (!empty($config->recycleonjoin)) {

--- a/locallib.php
+++ b/locallib.php
@@ -1018,3 +1018,83 @@ function zoom_get_api_url() {
     // Return API URL.
     return $apiurl;
 }
+
+/**
+ * Loads the zoom meeting and passes back a meeting url
+ * after processing events, view completion, grades, and license updates.
+ *
+ * @param int $id course module id
+ * @param object $context moodle context object
+ * @param bool $usestarturl
+ * @return array $returns contains url object 'nexturl' or string 'error'
+ */
+function zoom_load_meeting($id, $context, $usestarturl = true) {
+    global $CFG, $DB, $USER;
+    require_once($CFG->libdir . '/gradelib.php');
+
+    $cm         = get_coursemodule_from_id('zoom', $id, 0, false, MUST_EXIST);
+    $course     = get_course($cm->course);
+    $zoom  = $DB->get_record('zoom', array('id' => $cm->instance), '*', MUST_EXIST);
+
+    require_login($course, true, $cm);
+
+    require_capability('mod/zoom:view', $context);
+
+    $returns = array('nexturl' => null, 'error' => null);
+
+    list($inprogress, $available, $finished) = zoom_get_state($zoom);
+
+    // If the meeting is not yet available, deny access.
+    if ($available !== true) {
+        // Get unavailability note.
+        $returns['error'] = zoom_get_unavailability_note($zoom, $finished);
+        return $returns;
+    }
+
+    $userisrealhost = (zoom_get_user_id(false) === $zoom->host_id);
+    $alternativehosts = zoom_get_alternative_host_array_from_string($zoom->alternative_hosts);
+    $userishost = ($userisrealhost || in_array(zoom_get_api_identifier($USER), $alternativehosts, true));
+
+    // Check if we should use the start meeting url.
+    if ($userisrealhost && $usestarturl) {
+        // Important: Only the real host can use this URL, because it joins the meeting as the host user.
+        $returns['nexturl'] = new moodle_url($zoom->start_url);
+    } else {
+        $returns['nexturl'] = new moodle_url($zoom->join_url, array('uname' => fullname($USER)));
+    }
+
+    // Record user's clicking join.
+    \mod_zoom\event\join_meeting_button_clicked::create(array('context' => $context, 'objectid' => $zoom->id, 'other' =>
+            array('cmid' => $id, 'meetingid' => (int) $zoom->meeting_id, 'userishost' => $userishost)))->trigger();
+
+    // Track completion viewed.
+    $completion = new completion_info($course);
+    $completion->set_module_viewed($cm);
+
+    // Check whether user had a grade. If no, then assign full credits to him or her.
+    $gradelist = grade_get_grades($course->id, 'mod', 'zoom', $cm->instance, $USER->id);
+
+    // Assign full credits for user who has no grade yet, if this meeting is gradable (i.e. the grade type is not "None").
+    if (!empty($gradelist->items) && empty($gradelist->items[0]->grades[$USER->id]->grade)) {
+        $grademax = $gradelist->items[0]->grademax;
+        $grades = array('rawgrade' => $grademax,
+                        'userid' => $USER->id,
+                        'usermodified' => $USER->id,
+                        'dategraded' => '',
+                        'feedbackformat' => '',
+                        'feedback' => '');
+
+        zoom_grade_item_update($zoom, $grades);
+    }
+
+    // Upgrade host upon joining meeting, if host if not Licensed.
+    if ($userishost) {
+        $config = get_config('zoom');
+        if (!empty($config->recycleonjoin)) {
+            $service = new mod_zoom_webservice();
+            $service->provide_license($zoom->host_id);
+        }
+    }
+
+    return $returns;
+}


### PR DESCRIPTION
This addresses issue #304 

As discussed in patch #305 , I've moved the majority of the code from loadmeeting.php into a locallib function that can be used for both web and mobile app.

Setting the page context is handled differently in web and mobile (see [https://docs.moodle.org/dev/External_functions_API#Security](https://docs.moodle.org/dev/External_functions_API#Security)), so this is done before calling the new function, and the context is passed to the function. The context object is used to call the join_meeting_button_clicked event, so the only way to avoid passing context would be to pull that event out of the function.

Web and mobile handle redirects differently, so the function passes back a Moodle url object to be used in loadmeeting.php or /classes/external.php, but if the meeting is not available, it passes null for the url and returns the "meeting unavailable" string to be used in the Moodle redirect.