### PR TITLE
start_url: Always use a fresh copy if possible

### DIFF
--- a/index.php
+++ b/index.php
@@ -56,7 +56,6 @@ $stractions = get_string('actions', 'mod_zoom');
 $strsessions = get_string('sessions', 'mod_zoom');
 
 $strmeetingstarted = get_string('meeting_started', 'mod_zoom');
-$strstart = get_string('start', 'mod_zoom');
 $strjoin = get_string('join', 'mod_zoom');
 
 $PAGE->set_url('/mod/zoom/index.php', array('id' => $id));
@@ -162,15 +161,9 @@ foreach ($zooms as $z) {
         $row[3] = ($z->recurring && $z->recurrence_type == ZOOM_RECURRINGTYPE_NOTIME) ? '--' : format_time($z->duration);
 
         if ($available) {
-            if ($zoomuserid === false || $zoomuserid != $z->host_id) {
-                $buttonhtml = html_writer::tag('button', $strjoin,
-                        array('type' => 'submit', 'class' => 'btn btn-primary'));
-                $aurl = new moodle_url('/mod/zoom/loadmeeting.php', array('id' => $cm->id));
-            } else {
-                $buttonhtml = html_writer::tag('button', $strstart,
-                        array('type' => 'submit', 'class' => 'btn btn-success'));
-                $aurl = new moodle_url($z->start_url);
-            }
+            $buttonhtml = html_writer::tag('button', $strjoin,
+                array('type' => 'submit', 'class' => 'btn btn-primary'));
+            $aurl = new moodle_url('/mod/zoom/loadmeeting.php', array('id' => $cm->id));
             $buttonhtml .= html_writer::input_hidden_params($aurl);
             $row[4] = html_writer::tag('form', $buttonhtml, array('action' => $aurl->out_omit_querystring(), 'target' => '_blank'));
         } else {

--- a/locallib.php
+++ b/locallib.php
@@ -1058,7 +1058,8 @@ function zoom_load_meeting($id, $context, $usestarturl = true) {
     // Check if we should use the start meeting url.
     if ($userisrealhost && $usestarturl) {
         // Important: Only the real host can use this URL, because it joins the meeting as the host user.
-        $returns['nexturl'] = new moodle_url($zoom->start_url);
+        $starturl = zoom_get_start_url($zoom->meeting_id, $zoom->webinar, $zoom->join_url);
+        $returns['nexturl'] = new moodle_url($starturl);
     } else {
         $returns['nexturl'] = new moodle_url($zoom->join_url, array('uname' => fullname($USER)));
     }
@@ -1106,4 +1107,23 @@ function zoom_load_meeting($id, $context, $usestarturl = true) {
     }
 
     return $returns;
+}
+
+/**
+ * Fetches a fresh URL that can be used to start the Zoom meeting.
+ *
+ * @param string $meetingid Zoom meeting ID.
+ * @param bool $iswebinar If the session is a webinar.
+ * @param string $fallbackurl URL to use if the webservice call fails.
+ * @return string Best available URL for starting the meeting.
+ */
+function zoom_get_start_url($meetingid, $iswebinar, $fallbackurl) {
+    try {
+        $service = new mod_zoom_webservice();
+        $response = $service->get_meeting_webinar_info($meetingid, $iswebinar);
+        return $response->start_url ?? $response->join_url;
+    } catch (moodle_exception $e) {
+        // If an exception was thrown, gracefully use the fallback URL.
+        return $fallbackurl;
+    }
 }


### PR DESCRIPTION
The start_url expires after a couple hours, so it makes sense to me to get a fresh copy when it is needed.

As long as this works as expected, step two of this pull request would be to remove start_url from the database. At most, it could live in a time-limited cache, but I'm not sure that potential improvement is worth the overhead.