### PR TITLE
lib: Only update Zoom if the name has changed

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -373,7 +373,30 @@ function zoom_delete_instance($id) {
  * @return bool
  */
 function zoom_refresh_events($courseid, $zoom, $cm) {
-    return zoom_update_instance($zoom);
+    global $CFG;
+
+    require_once($CFG->dirroot . '/mod/zoom/classes/webservice.php');
+
+    try {
+        $service = new mod_zoom_webservice();
+
+        // Get the updated meeting info from zoom, before updating calendar events.
+        $response = $service->get_meeting_webinar_info($zoom->meeting_id, $zoom->webinar);
+        $fullzoom = populate_zoom_from_response($zoom, $response);
+
+        // Only if the name has changed, update meeting on Zoom.
+        if ($zoom->name !== $fullzoom->name) {
+            $fullzoom->name = $zoom->name;
+            $service->update_meeting($zoom);
+        }
+
+        zoom_calendar_item_update($fullzoom);
+        zoom_grade_item_update($fullzoom);
+    } catch (moodle_exception $error) {
+        return false;
+    }
+
+    return true;
 }
 
 /**


### PR DESCRIPTION
Right now, whenever `zoom_refresh_events()` is called, it's roughly the equivalent of editing the activity as a whole. This isn't ideal, because it might be that no data has changed or only superficial data.

Thanks to a helpful note in the function's documentation, I was reminded that this method is probably called when someone uses the "quick edit" Moodle UI feature. Whomever tests this should probably verify if `name` is the only value that can be modified via "quick edit". If not even `name` can be modified, then this code can be further simplified.

This is the first step in improving #301