### PR TITLE
Use 'title' as the Zoom event name label

### DIFF
--- a/index.php
+++ b/index.php
@@ -48,7 +48,7 @@ $strname = get_string('modulenameplural', 'mod_zoom');
 $strnew = get_string('newmeetings', 'mod_zoom');
 $strold = get_string('oldmeetings', 'mod_zoom');
 
-$strtopic = get_string('topic', 'mod_zoom');
+$strtitle = get_string('title', 'mod_zoom');
 $strwebinar = get_string('webinar', 'mod_zoom');
 $strtime = get_string('meeting_time', 'mod_zoom');
 $strduration = get_string('duration', 'mod_zoom');
@@ -77,11 +77,11 @@ $zoomuserid = zoom_get_user_id(false);
 
 $newtable = new html_table();
 $newtable->attributes['class'] = 'generaltable mod_index';
-$newhead = array($strtopic, $strtime, $strduration, $stractions);
+$newhead = array($strtitle, $strtime, $strduration, $stractions);
 $newalign = array('left', 'left', 'left', 'left');
 
 $oldtable = new html_table();
-$oldhead = array($strtopic, $strtime);
+$oldhead = array($strtitle, $strtime);
 $oldalign = array('left', 'left');
 
 // Show section column if there are sections.

--- a/mod_form.php
+++ b/mod_form.php
@@ -149,8 +149,8 @@ class mod_zoom_mod_form extends moodleform_mod {
         // Adding the "general" fieldset, where all the common settings are showed.
         $mform->addElement('header', 'general', get_string('general', 'form'));
 
-        // Add topic (stored in database as 'name').
-        $mform->addElement('text', 'name', get_string('topic', 'zoom'), array('size' => '64'));
+        // Add title (stored in database as 'name').
+        $mform->addElement('text', 'name', get_string('title', 'zoom'), array('size' => '64'));
         $mform->setType('name', PARAM_TEXT);
         $mform->addRule('name', null, 'required', null, 'client');
         $mform->addRule('name', get_string('maximumchars', '', 300), 'maxlength', 300, 'client');


### PR DESCRIPTION
Fixes #310 by using 'title' as the Zoom event name label, since 'topic' is already used throughout Moodle to indicate course sections.