### PR TITLE
release: v4.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ server is properly synchronized with the time servers.
 
 ## Changelog
 
+v4.2.1
+
+- Fix PHP 8 deprecation warning #332 (thanks @ndunand)
+- Fix duplicate column name on "All Meetings" page #330
+
 v4.2
 
 - Add support for Zoom Tracking Fields #308 (thanks @haietza, @porcospino)

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_zoom';
-$plugin->version = 2021111100;
-$plugin->release = 'v4.2';
+$plugin->version = 2021111700;
+$plugin->release = 'v4.2.1';
 $plugin->requires = 2017051500.00;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->cron = 0;


### PR DESCRIPTION
A couple delightfully small, yet important bug fixes

Addresses a usability/accessibility issue with a table; avoids a PHP warning that was adding noise (making life more difficult for system administrators)