### PR TITLE
tracking fields: always synchronize by coalescing to empty array

### DIFF
--- a/classes/task/update_meetings.php
+++ b/classes/task/update_meetings.php
@@ -161,7 +161,7 @@ class update_meetings extends \core\task\scheduled_task {
 
                 // Update tracking fields for meeting.
                 mtrace('  => Updated tracking fields for Zoom meeting ID ' . $zoom->meeting_id);
-                zoom_sync_meeting_tracking_fields($zoom->id, $response->tracking_fields);
+                zoom_sync_meeting_tracking_fields($zoom->id, $response->tracking_fields ?? array());
             }
         }
 

--- a/lib.php
+++ b/lib.php
@@ -116,9 +116,7 @@ function zoom_add_instance(stdClass $zoom, mod_zoom_mod_form $mform = null) {
     $zoom->id = $DB->insert_record('zoom', $zoom);
 
     // Store tracking field data for meeting.
-    if (isset($response->tracking_fields)) {
-        zoom_sync_meeting_tracking_fields($zoom->id, $response->tracking_fields);
-    }
+    zoom_sync_meeting_tracking_fields($zoom->id, $response->tracking_fields ?? array());
 
     zoom_calendar_item_update($zoom);
     zoom_grade_item_update($zoom);
@@ -187,9 +185,7 @@ function zoom_update_instance(stdClass $zoom, mod_zoom_mod_form $mform = null) {
     $zoom = populate_zoom_from_response($zoom, $response);
 
     // Update tracking field data for meeting.
-    if (isset($response->tracking_fields)) {
-        zoom_sync_meeting_tracking_fields($zoom->id, $response->tracking_fields);
-    }
+    zoom_sync_meeting_tracking_fields($zoom->id, $response->tracking_fields ?? array());
 
     zoom_calendar_item_update($zoom);
     zoom_grade_item_update($zoom);

--- a/locallib.php
+++ b/locallib.php
@@ -1128,7 +1128,7 @@ function zoom_list_tracking_fields() {
 
     // Get the tracking fields configured on the account.
     $response = $service->list_tracking_fields();
-    if ($response != null) {
+    if (isset($response->tracking_fields)) {
         foreach ($response->tracking_fields as $trackingfield) {
             $field = str_replace(' ', '_', strtolower($trackingfield->field));
             $trackingfields[$field] = (array) $trackingfield;


### PR DESCRIPTION
@haietza Please check to make sure I'm not forgetting something. This may also resolve an issue where a tracking field is added to a meeting (and synchronized to Moodle) and then later removed (but not synchronized to Moodle because there are no fields).

Fixes #336 