### PR TITLE
release: v4.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ server is properly synchronized with the time servers.
 
 ## Changelog
 
+v4.3.1
+
+- Fix database schema alignment and associated code #335 (thanks @TomoTsuyuki)
+- Run "Update Meetings" task once per day by default #342 (thanks @deraadt for reporting)
+  - Note: You may need to manually adjust your task schedule on existing installs.
+
 v4.3
 
 - Add support for Zoom Cloud Recordings #292 (thanks @jwalits, @nstefanski, @abias, ETH Zürich)

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_zoom';
-$plugin->version = 2021112900;
-$plugin->release = 'v4.3';
+$plugin->version = 2021120900;
+$plugin->release = 'v4.3.1';
 $plugin->requires = 2017051500.00;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->cron = 0;


### PR DESCRIPTION
There is an additional benefit of the associated code change in #335. There are situations where the meeting_id for an activity can change, such as when recreate.php is used on an expired meeting. By using the ID of the Zoom activity, associated entries will continue to be associated. This should mean that meeting reports and data cleanup on delete are more complete and consistent.