### PR TITLE
Compatibility with moodle-local_codechecker v3.0.5

### DIFF
--- a/backup/moodle2/backup_zoom_stepslib.php
+++ b/backup/moodle2/backup_zoom_stepslib.php
@@ -23,8 +23,6 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die;
-
 /**
  * Define the complete zoom structure for backup, with file and id annotations.
  */

--- a/classes/analytics/indicator/activity_base.php
+++ b/classes/analytics/indicator/activity_base.php
@@ -24,8 +24,6 @@
 
 namespace mod_zoom\analytics\indicator;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Activity base class.
  */

--- a/classes/analytics/indicator/cognitive_depth.php
+++ b/classes/analytics/indicator/cognitive_depth.php
@@ -24,8 +24,6 @@
 
 namespace mod_zoom\analytics\indicator;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Cognitive depth indicator - zoom.
  */

--- a/classes/analytics/indicator/social_breadth.php
+++ b/classes/analytics/indicator/social_breadth.php
@@ -24,8 +24,6 @@
 
 namespace mod_zoom\analytics\indicator;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Social breadth indicator.
  */

--- a/classes/event/course_module_instance_list_viewed.php
+++ b/classes/event/course_module_instance_list_viewed.php
@@ -24,8 +24,6 @@
 
 namespace mod_zoom\event;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * The mod_zoom instance list viewed event class.
  */

--- a/classes/event/course_module_viewed.php
+++ b/classes/event/course_module_viewed.php
@@ -24,8 +24,6 @@
 
 namespace mod_zoom\event;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * The mod_zoom instance list viewed event class
  *

--- a/classes/event/join_meeting_button_clicked.php
+++ b/classes/event/join_meeting_button_clicked.php
@@ -24,8 +24,6 @@
 
 namespace mod_zoom\event;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Records when a join meeting button is clicked.
  */

--- a/classes/invitation.php
+++ b/classes/invitation.php
@@ -25,8 +25,6 @@
 
 namespace mod_zoom;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Invitation class.
  */

--- a/classes/output/mobile.php
+++ b/classes/output/mobile.php
@@ -24,8 +24,6 @@
 
 namespace mod_zoom\output;
 
-defined('MOODLE_INTERNAL') || die();
-
 use context_module;
 use mod_zoom_external;
 

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -25,9 +25,6 @@
 
 namespace mod_zoom\privacy;
 
-defined('MOODLE_INTERNAL') || die();
-
-
 /**
  * Ad hoc task that performs the actions for approved data privacy requests.
  */

--- a/classes/search/activity.php
+++ b/classes/search/activity.php
@@ -24,8 +24,6 @@
 
 namespace mod_zoom\search;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Search area for mod_zoom activities.
  */

--- a/db/install.php
+++ b/db/install.php
@@ -22,8 +22,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die;
-
 /**
  * Post installation procedure
  *

--- a/db/uninstall.php
+++ b/db/uninstall.php
@@ -24,8 +24,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die;
-
 /**
  * Custom uninstallation procedure
  */

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -29,8 +29,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Execute zoom upgrade from the given old version
  *

--- a/lib.php
+++ b/lib.php
@@ -29,8 +29,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 /* Moodle core API */
 
 /**

--- a/tests/advanced_passcode_test.php
+++ b/tests/advanced_passcode_test.php
@@ -24,8 +24,6 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-global $CFG;
-require_once($CFG->dirroot.'/mod/zoom/locallib.php');
 namespace mod_zoom;
 
 use basic_testcase;
@@ -40,6 +38,14 @@ class advanced_passcode_test extends basic_testcase {
      * @var object
      */
     private $zoomdata;
+
+    /**
+     * Setup to ensure that fixtures are loaded.
+     */
+    public static function setUpBeforeClass(): void {
+        global $CFG;
+        require_once($CFG->dirroot . '/mod/zoom/locallib.php');
+    }
 
     /**
      * Tests that a default password of 6 numbers is created when settings are null.

--- a/tests/advanced_passcode_test.php
+++ b/tests/advanced_passcode_test.php
@@ -25,6 +25,7 @@
 namespace mod_zoom;
 
 use basic_testcase;
+use mod_zoom_webservice;
 
 /**
  * PHPunit testcase class.

--- a/tests/advanced_passcode_test.php
+++ b/tests/advanced_passcode_test.php
@@ -22,8 +22,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 namespace mod_zoom;
 
 use basic_testcase;

--- a/tests/advanced_passcode_test.php
+++ b/tests/advanced_passcode_test.php
@@ -26,6 +26,9 @@ defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 require_once($CFG->dirroot.'/mod/zoom/locallib.php');
+namespace mod_zoom;
+
+use basic_testcase;
 
 /**
  * PHPunit testcase class.

--- a/tests/error_handling_test.php
+++ b/tests/error_handling_test.php
@@ -25,6 +25,7 @@
 namespace mod_zoom;
 
 use basic_testcase;
+use zoom_not_found_exception;
 
 /**
  * PHPunit testcase class.
@@ -33,13 +34,13 @@ class error_handling_test extends basic_testcase {
 
     /**
      * Exception for when the meeting isn't found on Zoom.
-     * @var mod_zoom\zoom_not_found_exception
+     * @var zoom_not_found_exception
      */
     private $meetingnotfoundexception;
 
     /**
      * Exception for when the user isn't found on Zoom.
-     * @var mod_zoom\zoom_not_found_exception
+     * @var zoom_not_found_exception
      */
     private $usernotfoundexception;
 
@@ -47,13 +48,13 @@ class error_handling_test extends basic_testcase {
      * Exception for when the user is found in the system but they haven't
      * accepted their invite, so they don't have permissions to do what was
      * requested.
-     * @var mod_zoom\zoom_not_found_exception
+     * @var zoom_not_found_exception
      */
     private $invaliduserexception;
 
     /**
      * Exception for when the meeting isn't found on Zoom.
-     * @var mod_zoom\zoom_not_found_exception
+     * @var zoom_not_found_exception
      */
     private $othererrorcodeexception;
 

--- a/tests/error_handling_test.php
+++ b/tests/error_handling_test.php
@@ -22,8 +22,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 namespace mod_zoom;
 
 use basic_testcase;

--- a/tests/error_handling_test.php
+++ b/tests/error_handling_test.php
@@ -26,6 +26,9 @@ defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 require_once($CFG->dirroot.'/mod/zoom/locallib.php');
+namespace mod_zoom;
+
+use basic_testcase;
 
 /**
  * PHPunit testcase class.

--- a/tests/error_handling_test.php
+++ b/tests/error_handling_test.php
@@ -24,8 +24,6 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-global $CFG;
-require_once($CFG->dirroot.'/mod/zoom/locallib.php');
 namespace mod_zoom;
 
 use basic_testcase;
@@ -60,6 +58,14 @@ class error_handling_test extends basic_testcase {
      * @var mod_zoom\zoom_not_found_exception
      */
     private $othererrorcodeexception;
+
+    /**
+     * Setup to ensure that fixtures are loaded.
+     */
+    public static function setUpBeforeClass(): void {
+        global $CFG;
+        require_once($CFG->dirroot . '/mod/zoom/locallib.php');
+    }
 
     /**
      * Setup before every test.

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Zoom module test data generator class
  *

--- a/tests/get_meeting_reports_test.php
+++ b/tests/get_meeting_reports_test.php
@@ -24,7 +24,6 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-global $CFG;
 namespace mod_zoom;
 
 use advanced_testcase;

--- a/tests/get_meeting_reports_test.php
+++ b/tests/get_meeting_reports_test.php
@@ -25,6 +25,9 @@
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
+namespace mod_zoom;
+
+use advanced_testcase;
 
 /**
  * PHPunit testcase class.

--- a/tests/get_meeting_reports_test.php
+++ b/tests/get_meeting_reports_test.php
@@ -25,6 +25,8 @@
 namespace mod_zoom;
 
 use advanced_testcase;
+use mod_zoom_webservice;
+use stdClass;
 
 /**
  * PHPunit testcase class.
@@ -33,7 +35,7 @@ class get_meeting_reports_test extends advanced_testcase {
 
     /**
      * Scheduled task object.
-     * @var mod_zoom\task\get_meeting_reports
+     * @var \mod_zoom\task\get_meeting_reports
      */
     private $meetingtask;
 
@@ -67,7 +69,7 @@ class get_meeting_reports_test extends advanced_testcase {
     public function setUp(): void {
         $this->resetAfterTest(true);
 
-        $this->meetingtask = new mod_zoom\task\get_meeting_reports();
+        $this->meetingtask = new \mod_zoom\task\get_meeting_reports();
 
         $data = array('id' => 'ARANDOMSTRINGFORUUID',
             'user_id' => 123456789,
@@ -265,7 +267,7 @@ class get_meeting_reports_test extends advanced_testcase {
 
         // First mock the webservice object, so we can inject the return values
         // for get_meeting_participants.
-        $mockwwebservice = $this->createMock('mod_zoom_webservice');
+        $mockwwebservice = $this->createMock('\mod_zoom_webservice');
 
         // What we want get_meeting_participants to return.
         $participant1 = new stdClass();

--- a/tests/get_meeting_reports_test.php
+++ b/tests/get_meeting_reports_test.php
@@ -22,8 +22,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 namespace mod_zoom;
 
 use advanced_testcase;

--- a/tests/mod_zoom_grade_test.php
+++ b/tests/mod_zoom_grade_test.php
@@ -24,9 +24,6 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-global $CFG;
-require_once($CFG->dirroot.'/mod/zoom/lib.php');
-require_once($CFG->dirroot.'/mod/zoom/locallib.php');
 namespace mod_zoom;
 
 use advanced_testcase;
@@ -35,6 +32,15 @@ use advanced_testcase;
  * PHPunit testcase class.
  */
 class mod_zoom_grade_test extends advanced_testcase {
+
+    /**
+     * Setup to ensure that fixtures are loaded.
+     */
+    public static function setUpBeforeClass(): void {
+        global $CFG;
+        require_once($CFG->dirroot . '/mod/zoom/lib.php');
+        require_once($CFG->dirroot . '/mod/zoom/locallib.php');
+    }
 
     /**
      * Setup before every test.

--- a/tests/mod_zoom_grade_test.php
+++ b/tests/mod_zoom_grade_test.php
@@ -27,6 +27,9 @@ defined('MOODLE_INTERNAL') || die();
 global $CFG;
 require_once($CFG->dirroot.'/mod/zoom/lib.php');
 require_once($CFG->dirroot.'/mod/zoom/locallib.php');
+namespace mod_zoom;
+
+use advanced_testcase;
 
 /**
  * PHPunit testcase class.

--- a/tests/mod_zoom_grade_test.php
+++ b/tests/mod_zoom_grade_test.php
@@ -22,8 +22,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 namespace mod_zoom;
 
 use advanced_testcase;

--- a/tests/mod_zoom_invitation_test.php
+++ b/tests/mod_zoom_invitation_test.php
@@ -23,8 +23,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 namespace mod_zoom;
 
 use advanced_testcase;

--- a/tests/mod_zoom_invitation_test.php
+++ b/tests/mod_zoom_invitation_test.php
@@ -28,11 +28,14 @@ defined('MOODLE_INTERNAL') || die();
 global $CFG;
 
 require_once($CFG->libdir . '/accesslib.php');
+namespace mod_zoom;
+
+use advanced_testcase;
 
 /**
  * PHPunit testcase class for invitations.
  */
-class mod_zoom_invitation_testcase extends advanced_testcase {
+class mod_zoom_invitation_test extends advanced_testcase {
 
     /**
      * Run before every test.

--- a/tests/mod_zoom_invitation_test.php
+++ b/tests/mod_zoom_invitation_test.php
@@ -26,6 +26,9 @@
 namespace mod_zoom;
 
 use advanced_testcase;
+use context_system;
+use context_course;
+use moodle_url;
 
 /**
  * PHPunit testcase class for invitations.

--- a/tests/mod_zoom_invitation_test.php
+++ b/tests/mod_zoom_invitation_test.php
@@ -25,9 +25,6 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-global $CFG;
-
-require_once($CFG->libdir . '/accesslib.php');
 namespace mod_zoom;
 
 use advanced_testcase;
@@ -36,6 +33,14 @@ use advanced_testcase;
  * PHPunit testcase class for invitations.
  */
 class mod_zoom_invitation_test extends advanced_testcase {
+
+    /**
+     * Setup to ensure that fixtures are loaded.
+     */
+    public static function setUpBeforeClass(): void {
+        global $CFG;
+        require_once($CFG->libdir . '/accesslib.php');
+    }
 
     /**
      * Run before every test.

--- a/tests/mod_zoom_webservice_test.php
+++ b/tests/mod_zoom_webservice_test.php
@@ -27,6 +27,9 @@ defined('MOODLE_INTERNAL') || die();
 global $CFG;
 
 require_once($CFG->dirroot.'/mod/zoom/locallib.php');
+namespace mod_zoom;
+
+use advanced_testcase;
 
 /**
  * PHPunit testcase class.

--- a/tests/mod_zoom_webservice_test.php
+++ b/tests/mod_zoom_webservice_test.php
@@ -24,9 +24,6 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-global $CFG;
-
-require_once($CFG->dirroot.'/mod/zoom/locallib.php');
 namespace mod_zoom;
 
 use advanced_testcase;
@@ -35,6 +32,14 @@ use advanced_testcase;
  * PHPunit testcase class.
  */
 class mod_zoom_webservice_test extends advanced_testcase {
+
+    /**
+     * Setup to ensure that fixtures are loaded.
+     */
+    public static function setUpBeforeClass(): void {
+        global $CFG;
+        require_once($CFG->dirroot . '/mod/zoom/locallib.php');
+    }
 
     /**
      * Setup before every test.

--- a/tests/mod_zoom_webservice_test.php
+++ b/tests/mod_zoom_webservice_test.php
@@ -25,6 +25,9 @@
 namespace mod_zoom;
 
 use advanced_testcase;
+use mod_zoom_webservice;
+use moodle_exception;
+use zoom_api_retry_failed_exception;
 
 /**
  * PHPunit testcase class.

--- a/tests/mod_zoom_webservice_test.php
+++ b/tests/mod_zoom_webservice_test.php
@@ -22,8 +22,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 namespace mod_zoom;
 
 use advanced_testcase;


### PR DESCRIPTION
moodle-plugin-ci recently updated its moodle-local_codechecker dependency to v3.0.5. Some of the new checks are failing and it is actively preventing new code from being merged until this is fixed.