### PR TITLE
webservice: Specify HS256 when encoding

### DIFF
--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -213,7 +213,7 @@ class mod_zoom_webservice {
             'iss' => $this->apikey,
             'exp' => time() + 40
         );
-        $token = \Firebase\JWT\JWT::encode($payload, $this->apisecret);
+        $token = \Firebase\JWT\JWT::encode($payload, $this->apisecret, 'HS256');
         $curl->setHeader('Authorization: Bearer ' . $token);
 
         if ($method != 'get') {


### PR DESCRIPTION
This is required for forward-compatibility with Moodle 4.0 which has updated the php-jwt library to version 6.0. Thankfully, the only backward-incompatible change that appears to affect us is that the formerly-optional algorithm parameter - that defaulted to our desired value - is now a required parameter. As Zoom currently only allows one option, it makes sense for us to specify that algorithm in the code.

This is a high priority fix because we test against Moodle's master branch and that automated test is failing. This PR needs to be merged before we will be able to merge any other PRs.