### PR TITLE
release: v4.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ server is properly synchronized with the time servers.
 
 ## Changelog
 
+v4.3.3
+
+- Fix recording table database schema definitions #358 (thanks @jwalits)
+- Compatibility: Moodle upstream upgraded to php-jwt v6.0 #357
+- Renamed primary branch in GitHub to `main` #353
+
 v4.3.2
 
 - Only cache successful Zoom user ID values #350 (thanks @merrill-oakland)

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_zoom';
 $plugin->version = 2022022400;
-$plugin->release = 'v4.3.2';
+$plugin->release = 'v4.3.3';
 $plugin->requires = 2017051500.00;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->cron = 0;


### PR DESCRIPTION
A couple small fixes. 🎉 

### Notes on the bundled versions of php-jwt and version compatibility in general
Although Moodle upstream upgraded to php-jwt v6.0, it may be important to know that we did not change our version of php-jwt from v5.4.0. This is primarily because Moodle versions 3.7.x - 3.11.x already provide php-jwt v5.2.0 and that their copy gets loaded instead. Thankfully, this plugin currently only uses one method, `JWT::encode()`, so backward and forward compatibility are fairly simple. If we needed to have functionality from v6.0 of the php-jwt library, that would likely mean increasing our minimum Moodle version to 4.0.0 or providing some kind of backward compatibility for Moodle versions 3.7.x - 3.11.x. Interestingly, Moodle versions 3.3.x - 3.6.x would work just fine because of our bundled copy of php-jwt. Essentially that means that the version we bundle is only used by Moodle versions prior to 3.7.0, so at the point when we drop support for versions of Moodle prior to 3.7.0, we could remove our copy of php-jwt. The general philosophy has been to minimum backwards incompatible changes when possible and I do not know of any pending changes that would change our list of compatible Moodle versions. 