### PR TITLE
release: v4.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ server is properly synchronized with the time servers.
 
 ## Changelog
 
+v4.4.0
+
+- Feature: Allow configuration of section visibility on the view page #363 (thanks @aduranterres, @rayjbarrett1)
+  - New settings `zoom/defaultshowschedule`, `zoom/defaultshowsecurity`, `zoom/defaultshowmedia`
+  - New per activity settings `show_schedule`, `show_security`, `show_media`
+- Feature: Allow administrator to set webinar by default (when available) #367 (thanks @marcellobarile)
+  - New setting `zoom/webinardefault`
+- Code quality: specify code coverage for tests #367
+
 v4.3.4
 
 - Privacy: Add tests, support recordings, fix existing code #345 (thanks @jwalits, @tuanngocnguyen, @mattporritt, @marcghaly)

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_zoom';
-$plugin->version = 2022031600;
-$plugin->release = 'v4.3.4';
+$plugin->version = 2022040800;
+$plugin->release = 'v4.4.0';
 $plugin->requires = 2017051500.00;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->cron = 0;


### PR DESCRIPTION
A couple new optional features which default to the original behavior. As always, processing the upgrade steps are a required part of the plugin update process.

The code coverage updates for the tests was added to align with version 3.1.0 of Moodle's coding standard.