### PR TITLE
Ci/phpunit fix warnings

### DIFF
--- a/tests/advanced_passcode_test.php
+++ b/tests/advanced_passcode_test.php
@@ -107,8 +107,8 @@ class advanced_passcode_test extends basic_testcase {
 
         $passcode = zoom_create_default_passcode($this->zoomdata);
         $this->assertEquals(strlen($passcode), 6);
-        $this->assertRegExp('/\d/', $passcode);
-        $this->assertRegExp('/[a-zA-Z]/', $passcode);
+        $this->assertMatchesRegularExpression('/\d/', $passcode);
+        $this->assertMatchesRegularExpression('/[a-zA-Z]/', $passcode);
     }
 
     /**
@@ -125,9 +125,9 @@ class advanced_passcode_test extends basic_testcase {
 
         $passcode = zoom_create_default_passcode($this->zoomdata);
         $this->assertEquals(strlen($passcode), 6);
-        $this->assertRegExp('/\d/', $passcode);
-        $this->assertRegExp('/[A-Z]/', $passcode);
-        $this->assertRegExp('/[a-z]/', $passcode);
+        $this->assertMatchesRegularExpression('/\d/', $passcode);
+        $this->assertMatchesRegularExpression('/[A-Z]/', $passcode);
+        $this->assertMatchesRegularExpression('/[a-z]/', $passcode);
     }
 
     /**
@@ -144,8 +144,8 @@ class advanced_passcode_test extends basic_testcase {
 
         $passcode = zoom_create_default_passcode($this->zoomdata);
         $this->assertEquals(strlen($passcode), 6);
-        $this->assertRegExp('/\d/', $passcode);
-        $this->assertRegExp('/[^a-zA-Z\d]/', $passcode);
+        $this->assertMatchesRegularExpression('/\d/', $passcode);
+        $this->assertMatchesRegularExpression('/[^a-zA-Z\d]/', $passcode);
     }
 
     /**
@@ -162,9 +162,9 @@ class advanced_passcode_test extends basic_testcase {
 
         $passcode = zoom_create_default_passcode($this->zoomdata);
         $this->assertEquals(strlen($passcode), 7);
-        $this->assertRegExp('/\d/', $passcode);
-        $this->assertRegExp('/[a-zA-Z]/', $passcode);
-        $this->assertRegExp('/[^a-zA-Z\d]/', $passcode);
+        $this->assertMatchesRegularExpression('/\d/', $passcode);
+        $this->assertMatchesRegularExpression('/[a-zA-Z]/', $passcode);
+        $this->assertMatchesRegularExpression('/[^a-zA-Z\d]/', $passcode);
     }
 
     /**

--- a/tests/advanced_passcode_test.php
+++ b/tests/advanced_passcode_test.php
@@ -38,6 +38,23 @@ class advanced_passcode_test extends basic_testcase {
      */
     private $zoomdata;
 
+    // phpcs:disable moodle.NamingConventions.ValidFunctionName.LowercaseMethod
+    /**
+     * Backward compatibility support for PHPUnit 8 (PHP 7.2 and 7.3).
+     *
+     * @param string $pattern Regular expression.
+     * @param string $string String.
+     * @param string $message Message.
+     */
+    public static function assertMatchesRegularExpression($pattern, $string, $message = ''): void {
+        // phpcs:enable
+        if (method_exists('basic_testcase', 'assertMatchesRegularExpression')) {
+            parent::assertMatchesRegularExpression($pattern, $string, $message);
+        } else {
+            parent::assertRegExp($pattern, $string, $message);
+        }
+    }
+
     /**
      * Setup to ensure that fixtures are loaded.
      */


### PR DESCRIPTION
In PHPUnit 9, new aliases were created for some of the assert methods and the originals were deprecated. Unfortunately, forward compatibility was not added to PHPUnit 8 and PHPUnit 10 removes the deprecated methods. The developer has made it very clear that they are not going to change this behavior. This makes it very difficult to support multiple versions without a home-grown compatibility layer.

Hence the following:
- switch all methods to the new names
- override the new method in the test class to determine if we can truly use the new name

The benefit is that when we drop support for PHPUnit 8 (i.e. drop support for PHP 7.2 and 7.3), we will be able to remove the compatibility method and everything should just keep working.