### PR TITLE
Revert icon.svg for pre-moodle 4.0 activity icon

### DIFF
--- a/pix/icon.svg
+++ b/pix/icon.svg
@@ -1,5 +1,1 @@
-<?xml version="1.0" encoding="utf-8"?>
-<svg width="74.4px" height="74.4px" viewBox="0 0 24 24" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-     style="enable-background:new 0 0 74.4 74.4;" xml:space="preserve" preserveAspectRatio="xMinYMid meet">
-    <g><path fill-rule="evenodd" d="M24 12c0 6.629-5.371 12-12 12S0 18.629 0 12 5.371 0 12 0s12 5.371 12 12zm0 0 M16.219 13.77v-3.54l3.238-2.37v8.28zm0 0 M15.422 10.813c0-1.739-.965-2.954-2.856-2.954H4.543v5.286c0 1.87 1.148 2.996 2.871 2.996h8.008v-5.328zm0 0" fill="#fff"/></g>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><g fill-rule="evenodd"><path d="M24 12c0 6.629-5.371 12-12 12S0 18.629 0 12 5.371 0 12 0s12 5.371 12 12zm0 0" fill="#3f88ff"/><path d="M16.219 13.77v-3.54l3.238-2.37v8.28zm0 0M15.422 10.813c0-1.739-.965-2.954-2.856-2.954H4.543v5.286c0 1.87 1.148 2.996 2.871 2.996h8.008v-5.328zm0 0" fill="#fff"/></g></svg>


### PR DESCRIPTION
icon.svg is used prior to Moodle 4.0 
monologo.svg is used in Moodle 4.0 and beyond.

reverting icon.svg to it's original pre-moodle 4.0 state.

Fixes #374 