### PR TITLE
restore: Handle exceptions so overall restore can complete

### DIFF
--- a/backup/moodle2/restore_zoom_stepslib.php
+++ b/backup/moodle2/restore_zoom_stepslib.php
@@ -57,13 +57,13 @@ class restore_zoom_activity_structure_step extends restore_activity_structure_st
         global $DB;
 
         $data = (object)$data;
-        $service = new mod_zoom_webservice();
 
         // Update start_time before attempting to create a new meeting.
         $data->start_time = $this->apply_date_offset($data->start_time);
 
         // Either create a new meeting or set meeting as expired.
         try {
+            $service = new mod_zoom_webservice();
             $updateddata = $service->create_meeting($data);
             $data = populate_zoom_from_response($data, $updateddata);
             $data->exists_on_zoom = ZOOM_MEETING_EXISTS;


### PR DESCRIPTION
This should allow restores to complete even if the plugin has not yet been configured on the system.

Fixes #377 