### PR TITLE
ci: Treat PHPUnit warnings as failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: PHPUnit tests
         if: ${{ always() }}
-        run: moodle-plugin-ci phpunit
+        run: moodle-plugin-ci phpunit --fail-on-warning
 
       - name: Behat features
         if: ${{ always() }}


### PR DESCRIPTION
Mirror upstream changes in the recommended GitHub Action: https://github.com/moodlehq/moodle-plugin-ci/pull/165