### PR TITLE
error handling for security settings

### DIFF
--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -425,7 +425,7 @@ class mod_zoom_webservice {
      */
     public function get_account_meeting_security_settings() {
         $url = 'accounts/me/settings?option=meeting_security';
-        $response = null;
+        $response = (object) array('meeting_security' => (object) array());
         try {
             $response = $this->make_call($url);
             $meetingsecurity = $response->meeting_security;

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -444,7 +444,7 @@ class mod_zoom_webservice {
         }
 
         // Set a default encryption setting if it is not present.
-        if (!isset($meeting_security->end_to_end_encrypted_meetings)) {
+        if (!isset($meetingsecurity->end_to_end_encrypted_meetings)) {
             $meetingsecurity->end_to_end_encrypted_meetings = false;
         }
 

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -429,10 +429,10 @@ class mod_zoom_webservice {
             $response = $this->make_call($url);
             $meetingsecurity = $response->meeting_security;
         } catch (moodle_exception $error) {
+            // Only available for Paid account, return default settings.
             $meetingsecurity = new stdClass();
-            if ($error->zoomerrorcode == 200) {
-                // Only available for Paid account, return default settings.
-            } else {
+            // If some other error, show debug message.
+            if ($error->zoomerrorcode != 200) {
                 debugging($error->getMessage());
             }
         }

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -428,26 +428,27 @@ class mod_zoom_webservice {
         $response = null;
         try {
             $response = $this->make_call($url);
+            $meetingsecurity = $response->meeting_security;
         } catch (moodle_exception $error) {
             if ($error->zoomerrorcode == 200) {
                 // Only available for Paid account, return default settings.
-                $response = (object) array('meeting_security' => (object) array());
+                $meetingsecurity = new stdClass();
             } else {
                 debugging($error->getMessage());
             }
         }
 
         // Set a default meeting password requirment if it is not present.
-        if (!isset($response->meeting_security->meeting_password_requirement)) {
-              $response->meeting_security->meeting_password_requirement = (object) self::DEFAULT_MEETING_PASSWORD_REQUIREMENT;
+        if (!isset($meetingsecurity->meeting_password_requirement)) {
+              $meetingsecurity->meeting_password_requirement = (object) self::DEFAULT_MEETING_PASSWORD_REQUIREMENT;
         }
 
         // Set a default encryption setting if it is not present.
-        if (!isset($response->meeting_security->end_to_end_encrypted_meetings)) {
-            $response->meeting_security->end_to_end_encrypted_meetings = false;
+        if (!isset($meeting_security->end_to_end_encrypted_meetings)) {
+            $meetingsecurity->end_to_end_encrypted_meetings = false;
         }
 
-        return $response->meeting_security;
+        return $meetingsecurity;
     }
 
     /**

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -428,13 +428,25 @@ class mod_zoom_webservice {
         $response = null;
         try {
             $response = $this->make_call($url);
-            // Set a default meeting password requirment if it is not present.
-            if (!isset($response->meeting_security->meeting_password_requirement)) {
-                $response->meeting_security->meeting_password_requirement = (object) DEFAULT_MEETING_PASSWORD_REQUIREMENT;
-            }
         } catch (moodle_exception $error) {
-            throw $error;
+            if ($error->zoomerrorcode == 200) {
+                // Only available for Paid account, return default settings.
+                $response = (object) array('meeting_security' => (object) array());
+            } else {
+                debugging($error->getMessage());
+            }
         }
+
+        // Set a default meeting password requirment if it is not present.
+        if (!isset($response->meeting_security->meeting_password_requirement)) {
+              $response->meeting_security->meeting_password_requirement = (object) self::DEFAULT_MEETING_PASSWORD_REQUIREMENT;
+        }
+
+        // Set a default encryption setting if it is not present.
+        if (!isset($response->meeting_security->end_to_end_encrypted_meetings)) {
+            $response->meeting_security->end_to_end_encrypted_meetings = false;
+        }
+
         return $response->meeting_security;
     }
 

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -425,14 +425,13 @@ class mod_zoom_webservice {
      */
     public function get_account_meeting_security_settings() {
         $url = 'accounts/me/settings?option=meeting_security';
-        $response = (object) array('meeting_security' => (object) array());
         try {
             $response = $this->make_call($url);
             $meetingsecurity = $response->meeting_security;
         } catch (moodle_exception $error) {
+            $meetingsecurity = new stdClass();
             if ($error->zoomerrorcode == 200) {
                 // Only available for Paid account, return default settings.
-                $meetingsecurity = new stdClass();
             } else {
                 debugging($error->getMessage());
             }


### PR DESCRIPTION
Cleaner resolution for issues #228, #251, and #381. If the webservice receives the 200 error "Only available for Paid account" when trying to retrieve security settings, the default values are used instead.

Note: the caching error noted in the last pull request is gone, so likely that was caused by accidentally saving a null value in earlier testing.