### PR TITLE
tracking fields: gracefully catch exception on update

### DIFF
--- a/classes/task/update_tracking_fields.php
+++ b/classes/task/update_tracking_fields.php
@@ -63,7 +63,9 @@ class update_tracking_fields extends \core\task\scheduled_task {
         // Show trace message.
         mtrace('Starting to process existing Zoom tracking fields ...');
 
-        mod_zoom_update_tracking_fields();
+        if (!mod_zoom_update_tracking_fields()) {
+            mtrace('Error: Failed to update tracking fields.');
+        }
 
         // Show trace message.
         mtrace('Finished processing existing Zoom tracking fields');


### PR DESCRIPTION
An exception can occur when the Zoom plugin is not yet configured and the plugin is being installed. This catches the exception that occurs inside of a settings update callback so that it won't break other Moodle processes. When the Zoom plugin is configured, the scheduled task will automatically refresh the correct values, so this temporary delay in accuracy should be overall better.

Fixes #385 