### PR TITLE
release: v4.5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ server is properly synchronized with the time servers.
 
 ## Changelog
 
+v4.5.3
+
+- Bugfix: Allow plugin settings to update without a configuration exception #386 (thanks @acquaalta)
+
 v4.5.2
 
 - Regression: Avoid requiring paid accounts for meeting default settings #383 (thanks @nstefanski, @nickchen, @valeriy67, @obook)

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_zoom';
-$plugin->version = 2022051900;
-$plugin->release = 'v4.5.2';
+$plugin->version = 2022060200;
+$plugin->release = 'v4.5.3';
 $plugin->requires = 2017051500.00;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->cron = 0;


### PR DESCRIPTION
A small bugfix release so that someone who triggers the settings update callback for the tracking fields but has not yet configured the Zoom API credentials will still be able to process the rest of their changes.