### PR TITLE
breakout rooms: only send breakout_room setting when data exists

### DIFF
--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -620,8 +620,10 @@ class mod_zoom_webservice {
         }
         $data['tracking_fields'] = $tfarray;
 
-        $breakoutroom = array('enable' => true, 'rooms' => $zoom->breakoutrooms);
-        $data['settings']['breakout_room'] = $breakoutroom;
+        if (isset($zoom->breakoutrooms)) {
+            $breakoutroom = array('enable' => true, 'rooms' => $zoom->breakoutrooms);
+            $data['settings']['breakout_room'] = $breakoutroom;
+        }
 
         return $data;
     }


### PR DESCRIPTION
During restore of a previous backup of a Zoom activity, a warning message would occur:

> PHP Warning:  Undefined property: stdClass::$breakoutrooms in mod/zoom/classes/webservice.php on line 623
