### PR TITLE
release: v4.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ server is properly synchronized with the time servers.
 
 ## Changelog
 
+v4.6.2
+
+- Regression: Rename mustache templates for backward compatibility #398 (thanks @PhilipBeacon)
+  - Introduced in v4.6.0 by new mustache templates in sub-directories (a Moodle 3.8 feature).
+- Bugfix: Recognize the Webinar capabilities of a Zoom Events license #338 (thanks @dottbarbieri)
+- Bugfix: Avoid PHP Warning when restoring Zoom activities without breakout room data #399
+
 v4.6.1
 
 - Bugfix: Avoid JavaScript error when 'Show More' button does not exist #392 (thanks @mwithheld)

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_zoom';
-$plugin->version = 2022080400;
-$plugin->release = 'v4.6.1';
+$plugin->version = 2022081800;
+$plugin->release = 'v4.6.2';
 $plugin->requires = 2017051500.00;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->cron = 0;


### PR DESCRIPTION
A nice set of small fixes, one of which fixes a backward compatibility regression for users on Moodle versions prior to 3.8. While we do encourage people to use [versions of Moodle that are being actively supported](https://docs.moodle.org/dev/Releases#Version_support) by Moodle.org, it is beneficial for everyone if we can maintain broader compatibility with only a small adjustment to our code.