### PR TITLE
Enhancement/minimize api get user requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ v2.1
 v2.0.1
 
 - Fixing conflicts with Firebase\JWT library. If more conflicts are found,
-  please contact plugin maintainer to add whitelist in classes/webservice.php.
+  please contact plugin maintainer to add to list in classes/webservice.php.
 
 v2.0
 

--- a/backup/moodle2/restore_zoom_stepslib.php
+++ b/backup/moodle2/restore_zoom_stepslib.php
@@ -26,7 +26,6 @@
 defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot.'/mod/zoom/locallib.php');
-require_once($CFG->dirroot.'/mod/zoom/classes/webservice.php');
 
 /**
  * Structure step to restore one zoom activity
@@ -63,8 +62,7 @@ class restore_zoom_activity_structure_step extends restore_activity_structure_st
 
         // Either create a new meeting or set meeting as expired.
         try {
-            $service = new mod_zoom_webservice();
-            $updateddata = $service->create_meeting($data);
+            $updateddata = zoom_webservice()->create_meeting($data);
             $data = populate_zoom_from_response($data, $updateddata);
             $data->exists_on_zoom = ZOOM_MEETING_EXISTS;
         } catch (moodle_exception $e) {

--- a/classes/task/update_meetings.php
+++ b/classes/task/update_meetings.php
@@ -25,10 +25,6 @@
 
 namespace mod_zoom\task;
 
-defined('MOODLE_INTERNAL') || die();
-
-require_once($CFG->dirroot.'/mod/zoom/locallib.php');
-
 /**
  * Scheduled task to sychronize meeting data.
  */
@@ -58,9 +54,11 @@ class update_meetings extends \core\task\scheduled_task {
             mtrace('Skipping task - ', get_string('zoomerr_apisecret_missing', 'zoom'));
             return;
         }
+
         require_once($CFG->dirroot.'/lib/modinfolib.php');
         require_once($CFG->dirroot.'/mod/zoom/lib.php');
-        require_once($CFG->dirroot.'/mod/zoom/classes/webservice.php');
+        require_once($CFG->dirroot . '/mod/zoom/locallib.php');
+
         $service = new \mod_zoom_webservice();
 
         // Show trace message.

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -571,12 +571,12 @@ class mod_zoom_webservice {
             $recordingoption = get_config('zoom', 'recordingoption');
             if ($recordingoption === ZOOM_AUTORECORDING_USERDEFAULT) {
                 if (isset($zoom->schedule_for)) {
-                    $zoomuser = $this->get_user($zoom->schedule_for);
+                    $zoomuser = zoom_get_user($zoom->schedule_for);
                 } else {
                     $zoomapiidentifier = zoom_get_api_identifier($USER);
-                    $zoomuser = $this->get_user($zoomapiidentifier);
+                    $zoomuser = zoom_get_user($zoomapiidentifier);
                 }
-                $autorecording = $this->get_user_settings($zoomuser->id)->recording->auto_recording;
+                $autorecording = zoom_get_user_settings($zoomuser->id)->recording->auto_recording;
                 $data['settings']['auto_recording'] = $autorecording;
             } else {
                 $data['settings']['auto_recording'] = $recordingoption;

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -28,7 +28,7 @@ require_once($CFG->dirroot.'/mod/zoom/locallib.php');
 require_once($CFG->dirroot.'/lib/filelib.php');
 
 // Some plugins already might include this library, like mod_bigbluebuttonbn.
-// Hacky, but need to create whitelist of plugins that might have JWT library.
+// Hacky, but need to create list of plugins that might have JWT library.
 // NOTE: Remove file_exists checks and the JWT library in mod when versions prior to Moodle 3.7 is no longer supported.
 if (!class_exists('Firebase\JWT\JWT')) {
     if (file_exists($CFG->dirroot.'/lib/php-jwt/src/JWT.php')) {

--- a/exportical.php
+++ b/exportical.php
@@ -65,8 +65,7 @@ $ical->add_property('method', 'PUBLISH');
 $ical->add_property('prodid', '-//Moodle Pty Ltd//NONSGML Moodle Version ' . $CFG->version . '//EN');
 
 // Get the meeting invite note to add to the description property.
-$service = new mod_zoom_webservice();
-$meetinginvite = $service->get_meeting_invitation($zoom)->get_display_string($cm->id);
+$meetinginvite = zoom_webservice()->get_meeting_invitation($zoom)->get_display_string($cm->id);
 
 // Compute and add description property to event.
 $convertedtext = html_to_text($zoom->intro);

--- a/mod_form.php
+++ b/mod_form.php
@@ -50,12 +50,11 @@ class mod_zoom_mod_form extends moodleform_mod {
         $config = get_config('zoom');
         $PAGE->requires->css(new moodle_url('/mod/zoom/styles.css'));
         $PAGE->requires->js_call_amd("mod_zoom/form", 'init');
-        $zoomapiidentifier = zoom_get_api_identifier($USER);
 
         $isnew = empty($this->_cm);
 
-        $service = new mod_zoom_webservice();
-        $zoomuser = $service->get_user($zoomapiidentifier);
+        $zoomapiidentifier = zoom_get_api_identifier($USER);
+        $zoomuser = zoom_get_user($zoomapiidentifier);
 
         // If creating a new instance, but the Zoom user does not exist.
         if ($isnew && $zoomuser === false) {
@@ -73,7 +72,7 @@ class mod_zoom_mod_form extends moodleform_mod {
         $canschedule = false;
         if ($zoomuser !== false) {
             // Get the array of users they can schedule.
-            $canschedule = $service->get_schedule_for_users($zoomapiidentifier);
+            $canschedule = zoom_webservice()->get_schedule_for_users($zoomapiidentifier);
         }
 
         if (!empty($canschedule)) {
@@ -84,7 +83,7 @@ class mod_zoom_mod_form extends moodleform_mod {
             // If the activity exists and the current user is not the current host.
             if (!$isnew && $zoomuser->id !== $this->current->host_id) {
                 // Get intersection of current host's schedulers and $USER's schedulers to prevent zoom errors.
-                $currenthostschedulers = $service->get_schedule_for_users($this->current->host_id);
+                $currenthostschedulers = zoom_webservice()->get_schedule_for_users($this->current->host_id);
                 if (!empty($currenthostschedulers)) {
                     // Since this is the second argument to array_intersect_key,
                     // the entry from $canschedule will be used, so we can just
@@ -119,7 +118,7 @@ class mod_zoom_mod_form extends moodleform_mod {
         $meetinginfo = new stdClass();
         if (!$isnew) {
             try {
-                $meetinginfo = $service->get_meeting_webinar_info($this->current->meeting_id, $this->current->webinar);
+                $meetinginfo = zoom_webservice()->get_meeting_webinar_info($this->current->meeting_id, $this->current->webinar);
             } catch (moodle_exception $error) {
                 // If the meeting can't be found, offer to recreate the meeting on Zoom.
                 if (zoom_is_meeting_gone_error($error)) {
@@ -138,7 +137,7 @@ class mod_zoom_mod_form extends moodleform_mod {
         $allowschedule = false;
         if (!$isnew) {
             try {
-                $founduser = $service->get_user($meetinginfo->host_id);
+                $founduser = zoom_get_user($meetinginfo->host_id);
                 if ($founduser && array_key_exists($founduser->email, $scheduleusers)) {
                     $allowschedule = true;
                 }
@@ -295,7 +294,7 @@ class mod_zoom_mod_form extends moodleform_mod {
             // If we are creating a new instance.
             if ($isnew) {
                 // Check if the user has a webinar license.
-                $userfeatures = $service->get_user_settings($zoomuser->id)->feature;
+                $userfeatures = zoom_get_user_settings($zoomuser->id)->feature;
                 $haswebinarlicense = !empty($userfeatures->webinar) || !empty($userfeatures->zoom_events);
 
                 // Only show if the admin always wants to show this widget or
@@ -534,7 +533,7 @@ class mod_zoom_mod_form extends moodleform_mod {
             $options = array(
                 ZOOM_AUTORECORDING_NONE => get_string('autorecording_none', 'mod_zoom'),
             );
-            $recordingsettings = $service->get_user_settings($zoomuser->id)->recording;
+            $recordingsettings = zoom_get_user_settings($zoomuser->id)->recording;
 
             $localrecording = $recordingsettings->local_recording;
             if ($localrecording) {
@@ -614,7 +613,7 @@ class mod_zoom_mod_form extends moodleform_mod {
                 if (!$isnew) {
                     $mform->disabledIf('schedule_for', 'change_schedule_for');
                     $mform->addElement('checkbox', 'change_schedule_for', get_string('changehost', 'zoom'));
-                    $mform->setDefault('schedule_for', strtolower($service->get_user($this->current->host_id)->email));
+                    $mform->setDefault('schedule_for', strtolower(zoom_get_user($this->current->host_id)->email));
                 } else {
                     $mform->setDefault('schedule_for', strtolower($zoomapiidentifier));
                 }
@@ -680,7 +679,6 @@ class mod_zoom_mod_form extends moodleform_mod {
 
         $mform = $this->_form;
 
-        $service = new mod_zoom_webservice();
         if ($this->showschedulingprivilege) {
             $scheduleelement =& $mform->getElement('schedule_for');
             $values = $scheduleelement->getValue();
@@ -690,10 +688,10 @@ class mod_zoom_mod_form extends moodleform_mod {
             }
 
             $scheduleforuser = current($values);
-            $zoomuser = $service->get_user($scheduleforuser);
+            $zoomuser = zoom_get_user($scheduleforuser);
         } else {
             $zoomapiidentifier = zoom_get_api_identifier($USER);
-            $zoomuser = $service->get_user($zoomapiidentifier);
+            $zoomuser = zoom_get_user($zoomapiidentifier);
         }
 
         $recordingelement =& $mform->getElement('option_auto_recording');
@@ -703,7 +701,7 @@ class mod_zoom_mod_form extends moodleform_mod {
         $options = array(
             ZOOM_AUTORECORDING_NONE => get_string('autorecording_none', 'mod_zoom'),
         );
-        $recordingsettings = $service->get_user_settings($zoomuser->id)->recording;
+        $recordingsettings = zoom_get_user_settings($zoomuser->id)->recording;
 
         $localrecording = $recordingsettings->local_recording;
         if ($localrecording) {
@@ -895,16 +893,13 @@ class mod_zoom_mod_form extends moodleform_mod {
             }
         }
 
-        require_once($CFG->dirroot.'/mod/zoom/classes/webservice.php');
-        $service = new mod_zoom_webservice();
-
         if (!empty($data['requirepasscode']) && empty($data['meetingcode'])) {
             $errors['meetingcode'] = get_string('err_password_required', 'mod_zoom');
         }
 
         $zoomapiidentifier = zoom_get_api_identifier($USER);
         if (isset($data['schedule_for']) && strtolower($data['schedule_for']) !== strtolower($zoomapiidentifier)) {
-            $scheduleusers = $service->get_schedule_for_users($zoomapiidentifier);
+            $scheduleusers = zoom_webservice()->get_schedule_for_users($zoomapiidentifier);
             $scheduleok = false;
             foreach ($scheduleusers as $zuser) {
                 if (strtolower($zuser->email) === strtolower($data['schedule_for'])) {
@@ -926,7 +921,7 @@ class mod_zoom_mod_form extends moodleform_mod {
                 // Check if the listed alternative hosts are valid users on Zoom.
                 $alternativehosts = zoom_get_alternative_host_array_from_string($data['alternative_hosts']);
                 foreach ($alternativehosts as $alternativehost) {
-                    if (!($service->get_user($alternativehost))) {
+                    if (!(zoom_get_user($alternativehost))) {
                         $errors['alternative_hosts'] = get_string('zoomerr_alternativehostusernotfound', 'zoom', $alternativehost);
                         break;
                     }
@@ -936,7 +931,7 @@ class mod_zoom_mod_form extends moodleform_mod {
             } else if ($config->showalternativehosts == ZOOM_ALTERNATIVEHOSTS_PICKER) {
                 // Check if the picked alternative hosts are valid users on Zoom.
                 foreach ($data['alternative_hosts_picker'] as $alternativehost) {
-                    if (!($service->get_user($alternativehost))) {
+                    if (!(zoom_get_user($alternativehost))) {
                         $errors['alternative_hosts_picker'] =
                                 get_string('zoomerr_alternativehostusernotfound', 'zoom', $alternativehost);
                         break;

--- a/recordings.php
+++ b/recordings.php
@@ -71,8 +71,6 @@ if ($iszoommanager) {
     ];
 }
 
-$service = new mod_zoom_webservice();
-
 // Find all entries for this meeting in the database.
 $recordings = zoom_get_meeting_recordings_grouped($zoom->id);
 if (empty($recordings)) {

--- a/recreate.php
+++ b/recreate.php
@@ -26,7 +26,6 @@
 require_once(dirname(dirname(dirname(__FILE__))).'/config.php');
 require_once(dirname(__FILE__).'/lib.php');
 require_once(dirname(__FILE__).'/locallib.php');
-require_once(dirname(__FILE__).'/classes/webservice.php');
 
 list($course, $cm, $zoom) = zoom_get_instance_setup();
 
@@ -41,7 +40,6 @@ $PAGE->set_url('/mod/zoom/recreate.php', array('id' => $cm->id));
 // We will use the logged-in user's Zoom account to recreate,
 // in case the meeting's former owner no longer exists on Zoom.
 $zoom->host_id = zoom_get_user_id();
-$service = new mod_zoom_webservice();
 
 $trackingfields = $DB->get_records('zoom_meeting_tracking_fields', array('meeting_id' => $zoom->id));
 foreach ($trackingfields as $trackingfield) {
@@ -50,7 +48,7 @@ foreach ($trackingfields as $trackingfield) {
 }
 
 // Set the current zoom table entry to use the new meeting (meeting_id/etc).
-$response = $service->create_meeting($zoom);
+$response = zoom_webservice()->create_meeting($zoom);
 $zoom = populate_zoom_from_response($zoom, $response);
 $zoom->exists_on_zoom = ZOOM_MEETING_EXISTS;
 $zoom->timemodified = time();

--- a/settings.php
+++ b/settings.php
@@ -28,8 +28,6 @@ require_once($CFG->dirroot.'/mod/zoom/locallib.php');
 require_once($CFG->libdir . '/environmentlib.php');
 
 if ($ADMIN->fulltree) {
-    require_once($CFG->dirroot.'/mod/zoom/locallib.php');
-    require_once($CFG->dirroot.'/mod/zoom/classes/webservice.php');
     require_once($CFG->dirroot . '/mod/zoom/classes/invitation.php');
 
     $moodlehashideif = version_compare(normalize_version($CFG->release), '3.7.0', '>=');
@@ -42,8 +40,7 @@ if ($ADMIN->fulltree) {
         $notifyclass = 'notifysuccess';
         $errormessage = '';
         try {
-            $service = new mod_zoom_webservice();
-            $service->get_user(zoom_get_api_identifier($USER));
+            zoom_get_user(zoom_get_api_identifier($USER));
         } catch (moodle_exception $error) {
             $notifyclass = 'notifyproblem';
             $status = 'connectionfailed';

--- a/view.php
+++ b/view.php
@@ -65,9 +65,6 @@ $alternativehosts = zoom_get_alternative_host_array_from_string($zoom->alternati
 // Check if this user is the host or an alternative host.
 $userishost = ($userisrealhost || in_array(zoom_get_api_identifier($USER), $alternativehosts, true));
 
-// Get Zoom webservice instance.
-$service = new mod_zoom_webservice();
-
 // Get host user from Zoom.
 $hostuser = false;
 $showrecreate = false;
@@ -75,8 +72,8 @@ if ($zoom->exists_on_zoom == ZOOM_MEETING_EXPIRED) {
     $showrecreate = true;
 } else {
     try {
-        $service->get_meeting_webinar_info($zoom->meeting_id, $zoom->webinar);
-        $hostuser = $service->get_user($zoom->host_id);
+        zoom_webservice()->get_meeting_webinar_info($zoom->meeting_id, $zoom->webinar);
+        $hostuser = zoom_get_user($zoom->host_id);
     } catch (moodle_exception $error) {
         $showrecreate = zoom_is_meeting_gone_error($error);
 
@@ -103,7 +100,6 @@ if ($hostuser) {
     $hostmoodleuser->middlename = '';
 }
 
-$meetinginvite = $service->get_meeting_invitation($zoom)->get_display_string($cm->id);
 $isrecurringnotime = ($zoom->recurring && $zoom->recurrence_type == ZOOM_RECURRINGTYPE_NOTIME);
 
 $stryes = get_string('yes');
@@ -444,7 +440,7 @@ if ($zoom->show_media) {
             && ($zoom->option_audio === ZOOM_AUDIO_BOTH || $zoom->option_audio === ZOOM_AUDIO_TELEPHONY)
             && ($userishost || has_capability('mod/zoom:viewdialin', $context))) {
         // Get meeting invitation from Zoom.
-        $meetinginvite = $service->get_meeting_invitation($zoom)->get_display_string($cm->id);
+        $meetinginvite = zoom_webservice()->get_meeting_invitation($zoom)->get_display_string($cm->id);
         // Show meeting invitation if there is any.
         if (!empty($meetinginvite)) {
             $meetinginvitetext = str_replace("\r\n", '<br/>', $meetinginvite);


### PR DESCRIPTION
There are a lot of get_user() and get_user_settings() calls, which are often fetching the same information multiple times for a given page. As a first step, add some helper functions that avoid duplicating API calls for a single HTTP request. In the future, it would be easy to add a Moodle cache store so multiple HTTP requests can benefit from a single API call result, but cache invalidation is not a challenge for today.

Fixes #401 