### PR TITLE
mod_form: Also call moodleform_mod parent methods

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -670,6 +670,8 @@ class mod_zoom_mod_form extends moodleform_mod {
     public function definition_after_data() {
         global $USER;
 
+        parent::definition_after_data();
+
         // Get config.
         $config = get_config('zoom');
 
@@ -862,7 +864,8 @@ class mod_zoom_mod_form extends moodleform_mod {
      */
     public function validation($data, $files) {
         global $CFG, $USER;
-        $errors = array();
+
+        $errors = parent::validation($data, $files);
 
         $config = get_config('zoom');
 


### PR DESCRIPTION
`moodleform` is extended by `moodleform_mod` to provide baseline functionality for both forms and activity modules. However, when we override the methods, we need to remember to call the parent class method so that we still benefit from the baseline functionality before adding our own.

This regression was unintentionally a result of #390

Fixes #406 