### PR TITLE
No longer display activity introduction in v4.0 and later

### DIFF
--- a/view.php
+++ b/view.php
@@ -148,7 +148,7 @@ if ($showrecreate) {
 }
 
 // Show intro.
-if ($zoom->intro) {
+if ($zoom->intro && $CFG->branch < '400') {
     echo $OUTPUT->box(format_module_intro('zoom', $zoom, $cm->id), 'generalbox mod_introbox', 'intro');
 }
 


### PR DESCRIPTION
Moodle 4.0 moved the activity module's title, description, and activity completion into the standard module API (https://tracker.moodle.org/browse/MDL-72413). We identified the need to no longer display the activity title but did not identify the activity introduction (my fault). 

This pull request employees the same backwards compatible check used for the title.

Fixes #414 