### PR TITLE
webservice: Use HTTP/1.1 to avoid HTTP/2 OAuth endpoint issue

### DIFF
--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -983,6 +983,11 @@ class mod_zoom_webservice {
         $curl->setHeader('Authorization: Basic ' . base64_encode($this->clientid . ':' . $this->clientsecret));
         $curl->setHeader('Content-Type: application/json');
 
+        // Force HTTP/1.1 to avoid HTTP/2 "stream not closed" issue.
+        $curl->setopt(array(
+            'CURLOPT_HTTP_VERSION' => CURL_HTTP_VERSION_1_1,
+        ));
+
         $timecalled = time();
         $response = $this->make_curl_call($curl, 'post',
             'https://zoom.us/oauth/token?grant_type=account_credentials&account_id=' . $this->accountid, array());


### PR DESCRIPTION
As only a single request is made to this endpoint per hour, the simplicity of HTTP/1.1 avoids whatever underlying HTTP/2 bug was occurring in the original report. At some point in the future, HTTP/1.1 may be deprecated and the override should be able to be safely removed then.

Fixes #415 