### PR TITLE
release: v4.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ server is properly synchronized with the time servers.
 
 ## Changelog
 
+v4.8.1
+
+- Bugfix: Moodle 4 was displaying the activity description twice #417 (thanks @Laur0r, @haietza)
+- Bugfix: Avoid HTTP/2 error when using Server-to-Server OAuth #418 (thanks @phette23)
+
 v4.8.0
 
 - Feature: Support Server-to-Server OAuth app #387 (thanks @haietza, @mhughes2k)
@@ -84,6 +89,7 @@ v4.7.0
 - Feature: Allow automatic recording #390 (thanks @aduranterres, @lcollong)
   - New settings `zoom/recordingoption`, `zoom/allowrecordingchangeoption`
   - New per activity setting `option_auto_recording`
+  - Known issue: Causes pre-existing events to turn off automatic recording when edited.
 - Performance: Static caching of repeated API calls #402 (thanks @aduranterres)
 
 v4.6.2

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_zoom';
-$plugin->version = 2022092900;
-$plugin->release = 'v4.8.0';
+$plugin->version = 2022102000;
+$plugin->release = 'v4.8.1';
 $plugin->requires = 2017051500.00;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->cron = 0;


### PR DESCRIPTION
Small bugfix release to improve Moodle 4 compatibility and workaround an issue with certain versions of underlying libraries. I added a note to the automatic recording line from the previous release to highlight the known issue reported in #416. Hopefully we'll be able to test and release a fix for that known issue soon.