### PR TITLE
task: move all includes to consistent location

### DIFF
--- a/classes/task/get_meeting_recordings.php
+++ b/classes/task/get_meeting_recordings.php
@@ -51,7 +51,6 @@ class get_meeting_recordings extends \core\task\scheduled_task {
     public function execute() {
         global $DB;
 
-        $config = get_config('zoom');
         try {
             $service = zoom_webservice();
         } catch (\moodle_exception $exception) {
@@ -59,6 +58,7 @@ class get_meeting_recordings extends \core\task\scheduled_task {
             return;
         }
 
+        $config = get_config('zoom');
         if (empty($config->viewrecordings)) {
             mtrace('Skipping task - ', get_string('zoomerr_viewrecordings_off', 'zoom'));
             return;

--- a/classes/task/update_meetings.php
+++ b/classes/task/update_meetings.php
@@ -25,6 +25,12 @@
 
 namespace mod_zoom\task;
 
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->dirroot . '/lib/modinfolib.php');
+require_once($CFG->dirroot . '/mod/zoom/lib.php');
+require_once($CFG->dirroot . '/mod/zoom/locallib.php');
+
 /**
  * Scheduled task to sychronize meeting data.
  */
@@ -45,7 +51,7 @@ class update_meetings extends \core\task\scheduled_task {
      * @return boolean
      */
     public function execute() {
-        global $CFG, $DB;
+        global $DB;
 
         try {
             $service = zoom_webservice();
@@ -53,10 +59,6 @@ class update_meetings extends \core\task\scheduled_task {
             mtrace('Skipping task - ', $exception->getMessage());
             return;
         }
-
-        require_once($CFG->dirroot.'/lib/modinfolib.php');
-        require_once($CFG->dirroot.'/mod/zoom/lib.php');
-        require_once($CFG->dirroot . '/mod/zoom/locallib.php');
 
         // Show trace message.
         mtrace('Starting to process existing Zoom meeting activities ...');

--- a/classes/task/update_tracking_fields.php
+++ b/classes/task/update_tracking_fields.php
@@ -26,7 +26,8 @@ namespace mod_zoom\task;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->dirroot.'/mod/zoom/locallib.php');
+require_once($CFG->dirroot . '/mod/zoom/lib.php');
+require_once($CFG->dirroot . '/mod/zoom/locallib.php');
 
 /**
  * Scheduled task to sychronize tracking field data.
@@ -48,16 +49,12 @@ class update_tracking_fields extends \core\task\scheduled_task {
      * @return boolean
      */
     public function execute() {
-        global $CFG;
-
         try {
             zoom_webservice();
         } catch (\moodle_exception $exception) {
             mtrace('Skipping task - ', $exception->getMessage());
             return;
         }
-
-        require_once($CFG->dirroot . '/mod/zoom/lib.php');
 
         // Show trace message.
         mtrace('Starting to process existing Zoom tracking fields ...');


### PR DESCRIPTION
The includes all should happen together and for some of the tests to work, the includes need to happen before the public methods are called. There may be a better place that doesn't require side effects, but this at least makes all the tasks consistent and should resolve the reported issue.

Fixes #420 