### PR TITLE
Performance: Reduce API calls, respect host's settings

### DIFF
--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -610,11 +610,11 @@ class mod_zoom_webservice {
             if ($recordingoption === ZOOM_AUTORECORDING_USERDEFAULT) {
                 if (isset($zoom->schedule_for)) {
                     $zoomuser = zoom_get_user($zoom->schedule_for);
+                    $zoomuserid = $zoomuser->id;
                 } else {
-                    $zoomapiidentifier = zoom_get_api_identifier($USER);
-                    $zoomuser = zoom_get_user($zoomapiidentifier);
+                    $zoomuserid = zoom_get_user_id();
                 }
-                $autorecording = zoom_get_user_settings($zoomuser->id)->recording->auto_recording;
+                $autorecording = zoom_get_user_settings($zoomuserid)->recording->auto_recording;
                 $data['settings']['auto_recording'] = $autorecording;
             } else {
                 $data['settings']['auto_recording'] = $recordingoption;

--- a/view.php
+++ b/view.php
@@ -87,6 +87,13 @@ if ($zoom->exists_on_zoom == ZOOM_MEETING_EXPIRED) {
     }
 }
 
+/**
+ * Get the display name for a Zoom user.
+ * This is wrapped in a function to avoid unnecessary API calls.
+ *
+ * @param string $zoomuserid Zoom user ID.
+ * @return ?string
+ */
 function zoom_get_user_display_name($zoomuserid) {
     try {
         $hostuser = zoom_get_user($zoomuserid);


### PR DESCRIPTION
I noticed that we had several zoom_get_user() calls for the current user which were only ever using the Zoom user ID. So then I started checking all of the API calls on the view/edit pages to reduce API calls and improve data accuracy.

Fixes #430 