### PR TITLE
release: v4.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ server is properly synchronized with the time servers.
 
 ## Changelog
 
+v4.9.0
+
+- Feature: Allow Registration #412 (thanks @paulandm, @haietza, @MoleLR, @lcollong, @louisaoc)
+  - New settings `zoom/defaultregistration`
+  - New per activity setting `registration`
+- Bugfix: Update meetings task was throwing an exception #421 (thanks @lexxkoto)
+- Bugfix: Add missing cache definition language string #408 (thanks @aspark21)
+- Bugfix: Use user-level meeting security configuration #408
+  - Removed OAuth scope: `account:read:admin`
+- Regression: Moodle < 3.4 does not support hideIf()
+  - Introduced in v3.5 of this plugin while tidying the form UI.
+  - Minimum required Moodle version officially increased to 3.4.
+
 v4.8.1
 
 - Bugfix: Moodle 4 was displaying the activity description twice #417 (thanks @Laur0r, @haietza)

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_zoom';
-$plugin->version = 2022102700;
-$plugin->release = 'v4.8.1';
-$plugin->requires = 2017051500.00;
+$plugin->version = 2022110300;
+$plugin->release = 'v4.9.0';
+$plugin->requires = 2017111300;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->cron = 0;


### PR DESCRIPTION
A new optional feature and some very nice bug fixes. As for the minimum Moodle version increase, I guess no one was using Moodle 3.3 and noticed the hideIf() problem. As the plugin was only working on Moodle 3.4, I've retroactively fixed the supported versions on Moodle's plugin database and updated the required version in this latest release.