### PR TITLE
Fix/webservice error handling

### DIFF
--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -259,18 +259,18 @@ class mod_zoom_webservice {
             $curl->setHeader('Content-Type: application/json');
             $data = is_array($data) ? json_encode($data) : $data;
         }
-        $response = $this->make_curl_call($curl, $method, $url, $data);
+        $rawresponse = $this->make_curl_call($curl, $method, $url, $data);
 
         if ($curl->get_errno()) {
             throw new moodle_exception('errorwebservice', 'mod_zoom', '', $curl->error);
         }
 
-        $response = json_decode($response);
+        $response = json_decode($rawresponse);
 
         $httpstatus = $curl->get_info()['http_code'];
 
         if ($httpstatus >= 400) {
-            switch($httpstatus) {
+            switch ($httpstatus) {
                 case 400:
                     $errorstring = '';
                     if (!empty($response->errors)) {

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -272,7 +272,13 @@ class mod_zoom_webservice {
         if ($httpstatus >= 400) {
             switch($httpstatus) {
                 case 400:
-                    throw new zoom_bad_request_exception($response->message, $response->code);
+                    $errorstring = '';
+                    if (!empty($response->errors)) {
+                        foreach ($response->errors as $error) {
+                            $errorstring .= ' ' . $error->message;
+                        }
+                    }
+                    throw new zoom_bad_request_exception($response->message . $errorstring, $response->code);
                 case 404:
                     throw new zoom_not_found_exception($response->message, $response->code);
                 case 429:

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -253,6 +253,7 @@ class mod_zoom_webservice {
         }
 
         $curl->setHeader('Authorization: Bearer ' . $token);
+        $curl->setHeader('Accept: application/json');
 
         if ($method != 'get') {
             $curl->setHeader('Content-Type: application/json');


### PR DESCRIPTION
The passcode rules issue should already be fixed by #404. However, the error responses were coming back as XML instead of JSON in some cases. This change will always request JSON instead of accepting the default response format. We also add the specific error messages, if they exist, so the user has enough information to hopefully address the cause of the issue.

Fixes #424 