### PR TITLE
form: Start time in 5 minute intervals; default +1 hour

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -168,7 +168,11 @@ class mod_zoom_mod_form extends moodleform_mod {
         $mform->addElement('header', 'general', get_string('schedule', 'mod_zoom'));
 
         // Add date/time. Validation in validation().
-        $mform->addElement('date_time_selector', 'start_time', get_string('start_time', 'zoom'));
+        $starttimeoptions = array(
+            'step' => 5,
+            'defaulttime' => time() + 3600,
+        );
+        $mform->addElement('date_time_selector', 'start_time', get_string('start_time', 'zoom'), $starttimeoptions);
         // Start time needs to be enabled/disabled based on recurring checkbox as well recurrence_type.
         // Moved this control to javascript, rather than using disabledIf.
 


### PR DESCRIPTION
Moodle's default behavior for date_time_selector is to default to the current time and show every 1 minute interval as an option (which doesn't match the current documentation). Zoom's web interface shows 30 minute intervals while Zoom's app interface shows 15 minute intervals. In an effort to make the default user experience less painful without being too strict, we can use 5 minute intervals and set the default meeting time to an hour in the future. This issue is something that we've noticed constantly during testing, so this should help others who have been running into similar issues.