### PR TITLE
Replace removed zoom api id with zoom user id

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -430,7 +430,7 @@ class mod_zoom_mod_form extends moodleform_mod {
         $mform->addHelpButton('requirepasscode', 'requirepasscode', 'zoom');
 
         // Set default passcode and description from Zoom security settings.
-        $securitysettings = zoom_get_meeting_security_settings($this->current->host_id ?? $zoomapiidentifier);
+        $securitysettings = zoom_get_meeting_security_settings($this->current->host_id ?? $zoomuserid);
         // Add password.
         $mform->addElement('text', 'meetingcode', get_string('setpasscode', 'zoom'), array('maxlength' => '10'));
         $mform->setType('meetingcode', PARAM_TEXT);


### PR DESCRIPTION
Bug identified by issue #435.
Regression from pull request #422.

The zoom api identifier was removed from use and should be the zoom user id.  