### PR TITLE
delete_meeting_recordings: Process deletes one meetinguuid at a time

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -1245,17 +1245,21 @@ function zoom_get_meeting_recordings($zoomid = null) {
 /**
  * Get all meeting recordings grouped together.
  *
- * @param int $zoomid The id of the zoom meeting.
+ * @param int $zoomid Optional. The id of the zoom meeting.
  *
  * @return array All recordings for the zoom meeting grouped together.
  */
-function zoom_get_meeting_recordings_grouped($zoomid) {
+function zoom_get_meeting_recordings_grouped($zoomid = null) {
     global $DB;
 
-    $records = $DB->get_records('zoom_meeting_recordings', ['zoomid' => $zoomid], 'recordingstart ASC');
+    $params = [];
+    if ($zoomid !== null) {
+        $params['zoomid'] = $zoomid;
+    }
+    $records = $DB->get_records('zoom_meeting_recordings', $params, 'recordingstart ASC');
     $recordings = [];
     foreach ($records as $recording) {
-        $recordings[$recording->meetinguuid][] = $recording;
+        $recordings[$recording->meetinguuid][$recording->zoomrecordingid] = $recording;
     }
     return $recordings;
 }

--- a/recordings.php
+++ b/recordings.php
@@ -81,7 +81,7 @@ if (empty($recordings)) {
     $row = new html_table_row([$cell]);
     $table->data = [$row];
 } else {
-    foreach ($recordings as $timestart => $grouping) {
+    foreach ($recordings as $grouping) {
         // Output the related recordings into the same row.
         $recordingdate = '';
         $recordinghtml = '';


### PR DESCRIPTION
Previously the code would loop over all recordings collecting API responses for all related meeting UUIDs. That takes a long time and the process might expire before any cleanup was actually processed. Now, it should fetch one meeting UUID's list of recordings, process any deletes and move on to the next.

Fixes #437 