### PR TITLE
release: v4.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ server is properly synchronized with the time servers.
 
 ## Changelog
 
+v4.9.2
+
+- Bugfix: New meetings did not know which user to check for security settings #438 (thanks @haietza)
+- Bugfix: Use select field so registration option saves correctly #448 (thanks @paulandm)
+- Compatibility: grunt rebuild against Moodle 4.1 #446
+
 v4.9.1
 
 - Regression: Administrators without Zoom account were unable to edit #422 (thanks @juanbrunetmf)

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_zoom';
-$plugin->version = 2022111700;
-$plugin->release = 'v4.9.1';
+$plugin->version = 2023011200;
+$plugin->release = 'v4.9.2';
 $plugin->requires = 2017111300;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->cron = 0;


### PR DESCRIPTION
A couple small (in size) but significant bug fixes along with updates to our GitHub Action and build to align with the current Moodle LTS (4.1).