### PR TITLE
patch events for My Overview

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -676,12 +676,16 @@ function mod_zoom_core_calendar_provide_event_action(calendar_event $event,
     $zoom = $DB->get_record('zoom', ['id' => $cm->instance], '*');
     list($inprogress, $available, $finished) = zoom_get_state($zoom);
 
-    return $factory->create_instance(
-        get_string('join_meeting', 'zoom'),
-        new \moodle_url('/mod/zoom/view.php', ['id' => $cm->id]),
-        1,
-        $available
-    );
+    if ($finished) {
+        return null; // No point to showing finished meetings in overview.
+    } else {
+        return $factory->create_instance(
+            get_string('join_meeting', 'zoom'),
+            new \moodle_url('/mod/zoom/view.php', ['id' => $cm->id]),
+            1,
+            $available
+        );
+    }
 }
 
 /* Gradebook API */


### PR DESCRIPTION
This addresses issue #450 by returning null data if the Zoom meeting is finished, otherwise sharing the event info with the My Overview block. This should be backwards compatible, tested with Moodle 4.1 and 3.10.

Fixes #450 