### PR TITLE
moodle-cs and PSR-1/12 ruleset additions

### DIFF
--- a/backup/moodle2/backup_zoom_activity_task.class.php
+++ b/backup/moodle2/backup_zoom_activity_task.class.php
@@ -31,7 +31,6 @@ require_once($CFG->dirroot . '/mod/zoom/backup/moodle2/backup_zoom_stepslib.php'
  * Provides the steps to perform one complete backup of the zoom instance
  */
 class backup_zoom_activity_task extends backup_activity_task {
-
     /**
      * No specific settings for this activity
      */

--- a/backup/moodle2/backup_zoom_activity_task.class.php
+++ b/backup/moodle2/backup_zoom_activity_task.class.php
@@ -57,11 +57,11 @@ class backup_zoom_activity_task extends backup_activity_task {
         $base = preg_quote($CFG->wwwroot, '/');
 
         // Link to the list of zooms.
-        $search = '/('.$base.'\/mod\/zoom\/index.php\?id\=)([0-9]+)/';
+        $search = '/(' . $base . '\/mod\/zoom\/index.php\?id\=)([0-9]+)/';
         $content = preg_replace($search, '$@ZOOMINDEX*$2@$', $content);
 
         // Link to zoom view by moduleid.
-        $search = '/('.$base.'\/mod\/zoom\/view.php\?id\=)([0-9]+)/';
+        $search = '/(' . $base . '\/mod\/zoom\/view.php\?id\=)([0-9]+)/';
         $content = preg_replace($search, '$@ZOOMVIEWBYID*$2@$', $content);
 
         return $content;

--- a/backup/moodle2/backup_zoom_stepslib.php
+++ b/backup/moodle2/backup_zoom_stepslib.php
@@ -27,7 +27,6 @@
  * Define the complete zoom structure for backup, with file and id annotations.
  */
 class backup_zoom_activity_structure_step extends backup_activity_structure_step {
-
     /**
      * Defines the backup structure of the module.
      *

--- a/backup/moodle2/restore_zoom_activity_task.class.php
+++ b/backup/moodle2/restore_zoom_activity_task.class.php
@@ -33,7 +33,6 @@ require_once($CFG->dirroot . '/mod/zoom/backup/moodle2/restore_zoom_stepslib.php
  * Provides all the settings and steps to perform complete restore of the activity.
  */
 class restore_zoom_activity_task extends restore_activity_task {
-
     /**
      * Define (add) particular settings this activity can have
      */
@@ -72,7 +71,6 @@ class restore_zoom_activity_task extends restore_activity_task {
         $rules[] = new restore_decode_rule('ZOOMINDEX', '/mod/zoom/index.php?id=$1', 'course_module');
 
         return $rules;
-
     }
 
     /**

--- a/backup/moodle2/restore_zoom_stepslib.php
+++ b/backup/moodle2/restore_zoom_stepslib.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->dirroot.'/mod/zoom/locallib.php');
+require_once($CFG->dirroot . '/mod/zoom/locallib.php');
 
 /**
  * Structure step to restore one zoom activity

--- a/backup/moodle2/restore_zoom_stepslib.php
+++ b/backup/moodle2/restore_zoom_stepslib.php
@@ -31,7 +31,6 @@ require_once($CFG->dirroot . '/mod/zoom/locallib.php');
  * Structure step to restore one zoom activity
  */
 class restore_zoom_activity_structure_step extends restore_activity_structure_step {
-
     /**
      * Defines structure of path elements to be processed during the restore
      *

--- a/backup/moodle2/restore_zoom_stepslib.php
+++ b/backup/moodle2/restore_zoom_stepslib.php
@@ -38,7 +38,6 @@ class restore_zoom_activity_structure_step extends restore_activity_structure_st
      * @return array of restore_path_element
      */
     protected function define_structure() {
-
         $paths = [];
         $paths[] = new restore_path_element('zoom', '/activity/zoom');
         $paths[] = new restore_path_element('zoom_tracking_field', '/activity/zoom/trackingfields/trackingfield');

--- a/classes/analytics/indicator/activity_base.php
+++ b/classes/analytics/indicator/activity_base.php
@@ -28,7 +28,6 @@ namespace mod_zoom\analytics\indicator;
  * Activity base class.
  */
 abstract class activity_base extends \core_analytics\local\indicator\community_of_inquiry_activity {
-
     /**
      * Grading not implemented.
      *

--- a/classes/analytics/indicator/cognitive_depth.php
+++ b/classes/analytics/indicator/cognitive_depth.php
@@ -33,7 +33,7 @@ class cognitive_depth extends activity_base {
      *
      * @return object
      */
-    public static function get_name() : \lang_string {
+    public static function get_name(): \lang_string {
         return new \lang_string('indicator:cognitivedepth', 'mod_zoom');
     }
 

--- a/classes/analytics/indicator/cognitive_depth.php
+++ b/classes/analytics/indicator/cognitive_depth.php
@@ -28,7 +28,6 @@ namespace mod_zoom\analytics\indicator;
  * Cognitive depth indicator - zoom.
  */
 class cognitive_depth extends activity_base {
-
     /**
      * Returns the name.
      *

--- a/classes/analytics/indicator/social_breadth.php
+++ b/classes/analytics/indicator/social_breadth.php
@@ -28,7 +28,6 @@ namespace mod_zoom\analytics\indicator;
  * Social breadth indicator.
  */
 class social_breadth extends activity_base {
-
     /**
      * Returns the name.
      *

--- a/classes/analytics/indicator/social_breadth.php
+++ b/classes/analytics/indicator/social_breadth.php
@@ -35,7 +35,7 @@ class social_breadth extends activity_base {
      *
      * @return object
      */
-    public static function get_name() : \lang_string {
+    public static function get_name(): \lang_string {
         return new \lang_string('indicator:socialbreadth', 'mod_zoom');
     }
 

--- a/classes/event/course_module_viewed.php
+++ b/classes/event/course_module_viewed.php
@@ -31,7 +31,6 @@ namespace mod_zoom\event;
  * override methods get_url() and get_legacy_log_data(), too.
  */
 class course_module_viewed extends \core\event\course_module_viewed {
-
     /**
      * Initialize the event
      */

--- a/classes/event/join_meeting_button_clicked.php
+++ b/classes/event/join_meeting_button_clicked.php
@@ -28,7 +28,6 @@ namespace mod_zoom\event;
  * Records when a join meeting button is clicked.
  */
 class join_meeting_button_clicked extends \core\event\base {
-
     /**
      * Initializes the event.
      */

--- a/classes/external.php
+++ b/classes/external.php
@@ -33,7 +33,6 @@ require_once("$CFG->libdir/externallib.php");
  * Zoom external functions
  */
 class mod_zoom_external extends external_api {
-
     /**
      * Returns description of method parameters
      *

--- a/classes/external.php
+++ b/classes/external.php
@@ -92,6 +92,7 @@ class mod_zoom_external extends external_api {
             $result['start_time'] = $zoom->start_time;
             $result['duration'] = $zoom->duration;
         }
+
         $result['haspassword'] = (isset($zoom->password) && $zoom->password !== '');
         $result['joinbeforehost'] = $zoom->option_jbh;
         $result['startvideohost'] = $zoom->option_host_video;
@@ -111,6 +112,7 @@ class mod_zoom_external extends external_api {
         } else {
             $status = get_string('recurringmeetinglong', 'mod_zoom');
         }
+
         $result['status'] = $status;
 
         $result['warnings'] = $warnings;
@@ -194,6 +196,7 @@ class mod_zoom_external extends external_api {
             $warningmsg = clean_param($meetinginfo['error'], PARAM_TEXT);
             throw new invalid_response_exception($warningmsg);
         }
+
         $result['warnings'] = $warnings;
         return $result;
     }

--- a/classes/invitation.php
+++ b/classes/invitation.php
@@ -33,7 +33,7 @@ class invitation {
      * Invitation settings prefix.
      * @var string
      */
-    const PREFIX = 'invitation_';
+    public const PREFIX = 'invitation_';
 
     /** @var string|null $invitation The unaltered zoom invitation text. */
     private $invitation;

--- a/classes/invitation.php
+++ b/classes/invitation.php
@@ -29,7 +29,6 @@ namespace mod_zoom;
  * Invitation class.
  */
 class invitation {
-
     /**
      * Invitation settings prefix.
      * @var string

--- a/classes/invitation.php
+++ b/classes/invitation.php
@@ -63,24 +63,29 @@ class invitation {
         if (empty($this->invitation)) {
             return null;
         }
+
         // If regex patterns are disabled, return the raw zoom meeting invitation.
         if (!get_config('zoom', 'invitationregexenabled')) {
             return $this->invitation;
         }
+
         $displaystring = $this->invitation;
         try {
             // If setting enabled, strip the invite message.
             if (get_config('zoom', 'invitationremoveinvite')) {
                 $displaystring = $this->remove_element($displaystring, 'invite');
             }
+
             // If setting enabled, strip the iCal link.
             if (get_config('zoom', 'invitationremoveicallink')) {
                 $displaystring = $this->remove_element($displaystring, 'icallink');
             }
+
             // Check user capabilities, and remove parts of the invitation they don't have permission to view.
             if (!has_capability('mod/zoom:viewjoinurl', \context_module::instance($coursemoduleid), $userid)) {
                 $displaystring = $this->remove_element($displaystring, 'joinurl');
             }
+
             if (!has_capability('mod/zoom:viewdialin', \context_module::instance($coursemoduleid), $userid)) {
                 $displaystring = $this->remove_element($displaystring, 'onetapmobile');
                 $displaystring = $this->remove_element($displaystring, 'dialin');
@@ -95,6 +100,7 @@ class invitation {
             debugging($e->getMessage(), DEBUG_DEVELOPER);
             return $this->invitation;
         }
+
         $displaystring = trim($this->clean_paragraphs($displaystring));
         return $displaystring;
     }
@@ -160,6 +166,7 @@ class invitation {
         if (empty($configregex[$element])) {
             return $invitation;
         }
+
         $result = preg_match($configregex[$element], $invitation, $matches, PREG_OFFSET_CAPTURE);
         // If error occurred in preg_match, show debugging message to help site administrator.
         if ($result === false) {
@@ -167,10 +174,12 @@ class invitation {
                     ['element' => $element, 'pattern' => $configregex[$element]]),
                     DEBUG_DEVELOPER);
         }
+
         // No match found, so return invitation string unaltered.
         if (empty($matches)) {
             return $invitation;
         }
+
         // Get the position of the element in the full invitation string.
         $pos = $matches[0][1];
         // Inject a paragraph break above element. Use $this->clean_paragraphs() to fix uneven breaks between paragraphs.
@@ -201,6 +210,7 @@ class invitation {
         if ($this->configregex !== null) {
             return $this->configregex;
         }
+
         $config = get_config('zoom');
         $this->configregex = [];
         // Get the regex defined in the plugin settings for each element.
@@ -208,6 +218,7 @@ class invitation {
             $settingname = self::PREFIX . $element;
             $this->configregex[$element] = $config->$settingname;
         }
+
         return $this->configregex;
     }
 

--- a/classes/output/mobile.php
+++ b/classes/output/mobile.php
@@ -31,7 +31,6 @@ use mod_zoom_external;
  * Mobile output class for zoom
  */
 class mobile {
-
     /**
      * Returns the zoom course view for the mobile app,
      *  including meeting details and launch button (if applicable).

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -36,7 +36,6 @@ class provider implements
 
     // This plugin currently implements the original plugin_provider interface.
     \core_privacy\local\request\plugin\provider {
-
     /**
      * Returns meta data about this system.
      *

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -274,18 +274,21 @@ class provider implements
             foreach ($meetingdetails as $meetingdetail) {
                 $DB->delete_records('zoom_meeting_participants', ['detailsid' => $meetingdetail->id]);
             }
+
             $DB->delete_records('zoom_meeting_details', ['zoomid' => $cm->instance]);
 
             $meetingrecordings = $DB->get_records('zoom_meeting_recordings', ['zoomid' => $cm->instance]);
             foreach ($meetingrecordings as $recording) {
                 $DB->delete_records('zoom_meeting_recordings_view', ['recordingsid' => $recording->id]);
             }
+
             $DB->delete_records('zoom_meeting_recordings', ['zoomid' => $cm->instance]);
 
             $breakoutrooms = $DB->get_records('zoom_meeting_breakout_rooms', ['zoomid' => $cm->instance]);
             foreach ($breakoutrooms as $room) {
                 $DB->delete_records('zoom_breakout_participants', ['breakoutroomid' => $room->id]);
             }
+
             $DB->delete_records('zoom_meeting_breakout_rooms', ['zoomid' => $cm->instance]);
         }
     }
@@ -308,6 +311,7 @@ class provider implements
             if (!($context instanceof \context_module)) {
                 continue;
             }
+
             if ($cm = get_coursemodule_from_id('zoom', $context->instanceid)) {
                 $meetingdetails = $DB->get_records('zoom_meeting_details', ['zoomid' => $cm->instance]);
                 foreach ($meetingdetails as $meetingdetail) {

--- a/classes/search/activity.php
+++ b/classes/search/activity.php
@@ -28,7 +28,6 @@ namespace mod_zoom\search;
  * Search area for mod_zoom activities.
  */
 class activity extends \core_search\base_activity {
-
     /**
      * Returns true if this area uses file indexing.
      *

--- a/classes/task/get_meeting_recordings.php
+++ b/classes/task/get_meeting_recordings.php
@@ -91,6 +91,7 @@ class get_meeting_recordings extends \core\task\scheduled_task {
                                 mtrace('Recording id: ' . $zoomrecordinginfo->recordingid . ' exist(s)...skipping');
                                 continue;
                             }
+
                             $rec = new \stdClass();
                             $rec->zoomid = $zoom->id;
                             $rec->meetinguuid = trim($zoomrecordinginfo->meetinguuid);

--- a/classes/task/get_meeting_recordings.php
+++ b/classes/task/get_meeting_recordings.php
@@ -33,7 +33,6 @@ require_once($CFG->dirroot . '/mod/zoom/locallib.php');
  * Scheduled task to get the meeting recordings.
  */
 class get_meeting_recordings extends \core\task\scheduled_task {
-
     /**
      * Returns name of task.
      *

--- a/classes/task/get_meeting_reports.php
+++ b/classes/task/get_meeting_reports.php
@@ -62,6 +62,7 @@ class get_meeting_reports extends \core\task\scheduled_task {
         if ($a->end_time == $b->end_time) {
             return 0;
         }
+
         return ($a->end_time < $b->end_time) ? -1 : 1;
     }
 
@@ -107,6 +108,7 @@ class get_meeting_reports extends \core\task\scheduled_task {
             $endtime = time();
             $end = gmdate('Y-m-d', $endtime) . 'T' . gmdate('H:i:s', $endtime) . 'Z';
         }
+
         if (!empty($paramstart)) {
             $start = $paramstart;
         } else {
@@ -129,6 +131,7 @@ class get_meeting_reports extends \core\task\scheduled_task {
                 // exception to skip Dashboard API.
                 throw new \Exception('Querying $hostuuids; need to use Report API');
             }
+
             $allmeetings = $this->get_meetings_via_dashboard($start, $end);
         } catch (\Exception $e) {
             mtrace($e->getMessage());
@@ -173,6 +176,7 @@ class get_meeting_reports extends \core\task\scheduled_task {
                 }
             }
         }
+
         if ($recordedallmeetings && $runningastask) {
             // All finished, so save the time that we set end time for the initial query.
             set_config('last_call_made_at', $endtime, 'zoom');
@@ -245,6 +249,7 @@ class get_meeting_reports extends \core\task\scheduled_task {
         if ($participant->user_email == '') {
             $participant->user_email = null;
         }
+
         if ($participant->id == '') {
             $participant->id = null;
         }
@@ -279,6 +284,7 @@ class get_meeting_reports extends \core\task\scheduled_task {
             $names[$user->id] = $name;
             $emails[$user->id] = strtoupper(zoom_get_api_identifier($user));
         }
+
         return [$names, $emails];
     }
 
@@ -311,6 +317,7 @@ class get_meeting_reports extends \core\task\scheduled_task {
             // Else we just want a specific hosts.
             $activehostsuuids = $hostuuids;
         }
+
         $allmeetings = [];
         $localhosts = $DB->get_records_menu('zoom', null, '', 'id, host_id');
 
@@ -338,6 +345,7 @@ class get_meeting_reports extends \core\task\scheduled_task {
                 // Ignore hosts who hosted meetings outside of integration.
                 continue;
             }
+
             $this->debugmsg(sprintf('Found %d meetings for user', count($usersmeetings)));
             foreach ($usersmeetings as $usermeeting) {
                 $allmeetings[] = $usermeeting;
@@ -454,6 +462,7 @@ class get_meeting_reports extends \core\task\scheduled_task {
             mtrace('Meeting does not exist locally; skipping');
             return true;
         }
+
         $meeting->zoomid = $zoomrecord->id;
 
         // Insert or update meeting details.

--- a/classes/task/get_meeting_reports.php
+++ b/classes/task/get_meeting_reports.php
@@ -33,7 +33,6 @@ require_once($CFG->dirroot . '/mod/zoom/locallib.php');
  * Scheduled task to get the meeting participants for each .
  */
 class get_meeting_reports extends \core\task\scheduled_task {
-
     /**
      * Percentage in which we want similar_text to reach before we consider
      * using its results.

--- a/classes/task/get_meeting_reports.php
+++ b/classes/task/get_meeting_reports.php
@@ -37,7 +37,7 @@ class get_meeting_reports extends \core\task\scheduled_task {
      * Percentage in which we want similar_text to reach before we consider
      * using its results.
      */
-    const SIMILARNAME_THRESHOLD = 60;
+    private const SIMILARNAME_THRESHOLD = 60;
 
     /**
      * Used to determine if debugging is turned on or off for outputting messages.

--- a/classes/task/update_meetings.php
+++ b/classes/task/update_meetings.php
@@ -27,7 +27,7 @@ namespace mod_zoom\task;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->dirroot . '/lib/modinfolib.php');
+require_once($CFG->libdir . '/modinfolib.php');
 require_once($CFG->dirroot . '/mod/zoom/lib.php');
 require_once($CFG->dirroot . '/mod/zoom/locallib.php');
 

--- a/classes/task/update_meetings.php
+++ b/classes/task/update_meetings.php
@@ -35,7 +35,6 @@ require_once($CFG->dirroot . '/mod/zoom/locallib.php');
  * Scheduled task to sychronize meeting data.
  */
 class update_meetings extends \core\task\scheduled_task {
-
     /**
      * Returns name of task.
      *

--- a/classes/task/update_meetings.php
+++ b/classes/task/update_meetings.php
@@ -92,6 +92,7 @@ class update_meetings extends \core\task\scheduled_task {
                 // Show trace message.
                 mtrace('  !! Error updating Zoom meeting activity for Zoom meeting ID ' . $zoom->meeting_id . ': ' . $error);
             }
+
             if ($gotinfo) {
                 $changed = false;
                 $newzoom = populate_zoom_from_response($zoom, $response);

--- a/classes/task/update_meetings.php
+++ b/classes/task/update_meetings.php
@@ -72,10 +72,10 @@ class update_meetings extends \core\task\scheduled_task {
             // Show trace message.
             mtrace('Processing next Zoom meeting activity ...');
             mtrace('  Zoom meeting ID: ' . $zoom->meeting_id);
-            mtrace('  Zoom meeting title: '. $zoom->name);
+            mtrace('  Zoom meeting title: ' . $zoom->name);
             $zoomactivityurl = new \moodle_url('/mod/zoom/view.php', ['n' => $zoom->id]);
-            mtrace('  Zoom meeting activity URL: '. $zoomactivityurl->out());
-            mtrace('  Moodle course ID: '. $zoom->course);
+            mtrace('  Zoom meeting activity URL: ' . $zoomactivityurl->out());
+            mtrace('  Moodle course ID: ' . $zoom->course);
 
             $gotinfo = false;
             try {

--- a/classes/task/update_tracking_fields.php
+++ b/classes/task/update_tracking_fields.php
@@ -33,7 +33,6 @@ require_once($CFG->dirroot . '/mod/zoom/locallib.php');
  * Scheduled task to sychronize tracking field data.
  */
 class update_tracking_fields extends \core\task\scheduled_task {
-
     /**
      * Returns name of task.
      *

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -50,13 +50,13 @@ class mod_zoom_webservice {
      * API calls: maximum number of retries.
      * @var int
      */
-    const MAX_RETRIES = 5;
+    public const MAX_RETRIES = 5;
 
     /**
      * Default meeting_password_requirement object.
      * @var array
      */
-    const DEFAULT_MEETING_PASSWORD_REQUIREMENT = [
+    public const DEFAULT_MEETING_PASSWORD_REQUIREMENT = [
         'length' => 0,
         'consecutive_characters_length' => 0,
         'have_letter' => false,

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -173,6 +173,7 @@ class mod_zoom_webservice {
                 $this->recyclelicenses = $config->utmost;
                 $this->instanceusers = !empty($config->instanceusers);
             }
+
             if ($this->recyclelicenses) {
                 if (!empty($config->licensesnumber)) {
                     $this->numlicenses = $config->licensesnumber;
@@ -238,6 +239,7 @@ class mod_zoom_webservice {
             $CFG->proxyuser = '';
             $CFG->proxypassword = '';
         }
+
         $curl = $this->get_curl_object(); // Create $curl, which implicitly uses the proxy settings from $CFG.
         if (!empty($proxyhost)) {
             // Restore the stored global proxy settings from above.
@@ -266,6 +268,7 @@ class mod_zoom_webservice {
             $curl->setHeader('Content-Type: application/json');
             $data = is_array($data) ? json_encode($data) : $data;
         }
+
         $rawresponse = $this->make_curl_call($curl, $method, $url, $data);
 
         if ($curl->get_errno()) {
@@ -293,6 +296,7 @@ class mod_zoom_webservice {
                     if ($this->makecallretries > self::MAX_RETRIES) {
                         throw new zoom_api_retry_failed_exception($response->message, $response->code);
                     }
+
                     $header = $curl->getResponse();
                     // Header can have mixed case, normalize it.
                     $header = array_change_key_case($header, CASE_LOWER);
@@ -336,6 +340,7 @@ class mod_zoom_webservice {
                     }
             }
         }
+
         $this->makecallretries = 0;
 
         return $response;
@@ -417,6 +422,7 @@ class mod_zoom_webservice {
         if (empty(self::$userslist)) {
             self::$userslist = $this->make_paginated_call('users', null, 'users');
         }
+
         return self::$userslist;
     }
 
@@ -441,6 +447,7 @@ class mod_zoom_webservice {
                 }
             }
         }
+
         return false;
     }
 
@@ -555,6 +562,7 @@ class mod_zoom_webservice {
             if (is_array($response->schedulers)) {
                 $schedulerswithoutkey = $response->schedulers;
             }
+
             foreach ($schedulerswithoutkey as $s) {
                 $schedulers[$s->id] = $s;
             }
@@ -562,6 +570,7 @@ class mod_zoom_webservice {
             // We don't care if this throws an exception.
             $schedulers = [];
         }
+
         return $schedulers;
     }
 
@@ -587,23 +596,29 @@ class mod_zoom_webservice {
         if (isset($zoom->intro)) {
             $data['agenda'] = content_to_text($zoom->intro, FORMAT_MOODLE);
         }
+
         if (isset($CFG->timezone) && !empty($CFG->timezone)) {
             $data['timezone'] = $CFG->timezone;
         } else {
             $data['timezone'] = date_default_timezone_get();
         }
+
         if (isset($zoom->password)) {
             $data['password'] = $zoom->password;
         }
+
         if (isset($zoom->schedule_for)) {
             $data['schedule_for'] = $zoom->schedule_for;
         }
+
         if (isset($zoom->alternative_hosts)) {
             $data['settings']['alternative_hosts'] = $zoom->alternative_hosts;
         }
+
         if (isset($zoom->option_authenticated_users)) {
             $data['settings']['meeting_authentication'] = (bool) $zoom->option_authenticated_users;
         }
+
         if (isset($zoom->registration)) {
             $data['settings']['approval_type'] = $zoom->registration;
         }
@@ -641,6 +656,7 @@ class mod_zoom_webservice {
                 } else {
                     $zoomuserid = zoom_get_user_id();
                 }
+
                 $autorecording = zoom_get_user_settings($zoomuserid)->recording->auto_recording;
                 $data['settings']['auto_recording'] = $autorecording;
             } else {
@@ -666,6 +682,7 @@ class mod_zoom_webservice {
             if ($zoom->recurrence_type == ZOOM_RECURRINGTYPE_WEEKLY) {
                 $data['recurrence']['weekly_days'] = $zoom->weekly_days;
             }
+
             if ($zoom->recurrence_type == ZOOM_RECURRINGTYPE_MONTHLY) {
                 if ($zoom->monthly_repeat_option == ZOOM_MONTHLY_REPEAT_OPTION_DAY) {
                     $data['recurrence']['monthly_day'] = (int) $zoom->monthly_day;
@@ -674,6 +691,7 @@ class mod_zoom_webservice {
                     $data['recurrence']['monthly_week_day'] = (int) $zoom->monthly_week_day;
                 }
             }
+
             if ($zoom->end_date_option == ZOOM_END_DATE_OPTION_AFTER) {
                 $data['recurrence']['end_times'] = (int) $zoom->end_times;
             } else {
@@ -701,6 +719,7 @@ class mod_zoom_webservice {
                 $tfarray[] = $tf;
             }
         }
+
         $data['tracking_fields'] = $tfarray;
 
         if (isset($zoom->breakoutrooms)) {
@@ -725,6 +744,7 @@ class mod_zoom_webservice {
                 // Changes least_recently_active_user to a basic user so we can use their license.
                 $this->make_call("users/$leastrecentlyactivepaiduserid", ['type' => ZOOM_USER_TYPE_BASIC], 'patch');
             }
+
             // Changes current user to pro so they can make a meeting.
             $this->make_call("users/$zoomuserid", ['type' => ZOOM_USER_TYPE_PRO], 'patch');
         }
@@ -795,6 +815,7 @@ class mod_zoom_webservice {
         if ($zoom->webinar) {
             return new \mod_zoom\invitation(null);
         }
+
         $url = 'meetings/' . $zoom->meeting_id . '/invitation';
         try {
             $response = $this->make_call($url);
@@ -802,6 +823,7 @@ class mod_zoom_webservice {
             debugging($error->getMessage());
             return new \mod_zoom\invitation(null);
         }
+
         return new \mod_zoom\invitation($response->invitation);
     }
 
@@ -860,6 +882,7 @@ class mod_zoom_webservice {
         foreach ($users as $user) {
             $uuids[] = $user->id;
         }
+
         return $uuids;
     }
 
@@ -914,6 +937,7 @@ class mod_zoom_webservice {
         } catch (moodle_exception $error) {
             debugging($error->getMessage());
         }
+
         return $response;
     }
 
@@ -973,12 +997,14 @@ class mod_zoom_webservice {
                         $recordings[strtotime($rec->recording_start)][] = $recordinginfo;
                     }
                 }
+
                 ksort($recordings);
             }
         } catch (moodle_exception $error) {
             // No recordings found for this meeting id.
             $recordings = [];
         }
+
         return $recordings;
     }
 
@@ -995,6 +1021,7 @@ class mod_zoom_webservice {
         if (empty($token) || empty($expires) || time() >= $expires) {
             $token = $this->oauth($cache);
         }
+
         return $token;
     }
 
@@ -1033,6 +1060,7 @@ class mod_zoom_webservice {
             } else {
                 $expires = 3599 + $timecalled;
             }
+
             $cache->set('expires', $expires);
 
             return $token;

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -25,14 +25,14 @@
 defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot . '/mod/zoom/locallib.php');
-require_once($CFG->dirroot . '/lib/filelib.php');
+require_once($CFG->libdir . '/filelib.php');
 
 // Some plugins already might include this library, like mod_bigbluebuttonbn.
 // Hacky, but need to create list of plugins that might have JWT library.
 // NOTE: Remove file_exists checks and the JWT library in mod when versions prior to Moodle 3.7 is no longer supported.
 if (!class_exists('Firebase\JWT\JWT')) {
-    if (file_exists($CFG->dirroot . '/lib/php-jwt/src/JWT.php')) {
-        require_once($CFG->dirroot . '/lib/php-jwt/src/JWT.php');
+    if (file_exists($CFG->libdir . '/php-jwt/src/JWT.php')) {
+        require_once($CFG->libdir . '/php-jwt/src/JWT.php');
     } else {
         if (file_exists($CFG->dirroot . '/mod/bigbluebuttonbn/vendor/firebase/php-jwt/src/JWT.php')) {
             require_once($CFG->dirroot . '/mod/bigbluebuttonbn/vendor/firebase/php-jwt/src/JWT.php');

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -24,20 +24,20 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->dirroot.'/mod/zoom/locallib.php');
-require_once($CFG->dirroot.'/lib/filelib.php');
+require_once($CFG->dirroot . '/mod/zoom/locallib.php');
+require_once($CFG->dirroot . '/lib/filelib.php');
 
 // Some plugins already might include this library, like mod_bigbluebuttonbn.
 // Hacky, but need to create list of plugins that might have JWT library.
 // NOTE: Remove file_exists checks and the JWT library in mod when versions prior to Moodle 3.7 is no longer supported.
 if (!class_exists('Firebase\JWT\JWT')) {
-    if (file_exists($CFG->dirroot.'/lib/php-jwt/src/JWT.php')) {
-        require_once($CFG->dirroot.'/lib/php-jwt/src/JWT.php');
+    if (file_exists($CFG->dirroot . '/lib/php-jwt/src/JWT.php')) {
+        require_once($CFG->dirroot . '/lib/php-jwt/src/JWT.php');
     } else {
-        if (file_exists($CFG->dirroot.'/mod/bigbluebuttonbn/vendor/firebase/php-jwt/src/JWT.php')) {
-            require_once($CFG->dirroot.'/mod/bigbluebuttonbn/vendor/firebase/php-jwt/src/JWT.php');
+        if (file_exists($CFG->dirroot . '/mod/bigbluebuttonbn/vendor/firebase/php-jwt/src/JWT.php')) {
+            require_once($CFG->dirroot . '/mod/bigbluebuttonbn/vendor/firebase/php-jwt/src/JWT.php');
         } else {
-            require_once($CFG->dirroot.'/mod/zoom/jwt/JWT.php');
+            require_once($CFG->dirroot . '/mod/zoom/jwt/JWT.php');
         }
     }
 }

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -46,7 +46,6 @@ if (!class_exists('Firebase\JWT\JWT')) {
  * Web service class.
  */
 class mod_zoom_webservice {
-
     /**
      * API calls: maximum number of retries.
      * @var int

--- a/cli/get_meeting_report.php
+++ b/cli/get_meeting_report.php
@@ -24,7 +24,7 @@
 
 define('CLI_SCRIPT', true);
 
-require(__DIR__.'/../../../config.php');
+require(__DIR__ . '/../../../config.php');
 require_once($CFG->libdir . '/clilib.php');
 
 // Now get cli options.

--- a/console/get_meeting_report.php
+++ b/console/get_meeting_report.php
@@ -22,8 +22,8 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once(__DIR__.'/../../../config.php');
-require_once(dirname(__FILE__).'/../../../lib/moodlelib.php');
+require_once(__DIR__ . '/../../../config.php');
+require_once(dirname(__FILE__) . '/../../../lib/moodlelib.php');
 
 // Force debugging errors.
 error_reporting(E_ALL);

--- a/console/get_meeting_report.php
+++ b/console/get_meeting_report.php
@@ -22,7 +22,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once(__DIR__ . '/../../../config.php');
+require(__DIR__ . '/../../../config.php');
 require_once($CFG->libdir . '/moodlelib.php');
 
 // Force debugging errors.

--- a/console/get_meeting_report.php
+++ b/console/get_meeting_report.php
@@ -23,7 +23,7 @@
  */
 
 require_once(__DIR__ . '/../../../config.php');
-require_once(dirname(__FILE__) . '/../../../lib/moodlelib.php');
+require_once($CFG->libdir . '/moodlelib.php');
 
 // Force debugging errors.
 error_reporting(E_ALL);

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -81,6 +81,7 @@ function xmldb_zoom_upgrade($oldversion) {
             $time->start_time = strtotime($time->start_time);
             $DB->update_record('zoom', $time);
         }
+
         $starttimes->close();
         $dbman->change_field_type($table, $field);
 
@@ -267,7 +268,6 @@ function xmldb_zoom_upgrade($oldversion) {
     }
 
     if ($oldversion < 2018092201) {
-
         // Changing type of field userid on table zoom_meeting_participants to int.
         $table = new xmldb_table('zoom_meeting_participants');
 
@@ -301,6 +301,7 @@ function xmldb_zoom_upgrade($oldversion) {
         if ($dbman->field_exists($table, $field)) {
             $dbman->change_field_notnull($table, $field);
         }
+
         // Zoom savepoint reached.
         upgrade_mod_savepoint(true, 2019061800, 'zoom');
     }
@@ -715,7 +716,6 @@ function xmldb_zoom_upgrade($oldversion) {
     }
 
     if ($oldversion < 2022022400) {
-
         // Change the recordings_visible_default field in the zoom table.
         $table = new xmldb_table('zoom');
         $field = new xmldb_field('recordings_visible_default', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '1',
@@ -732,7 +732,6 @@ function xmldb_zoom_upgrade($oldversion) {
     }
 
     if ($oldversion < 2022031600) {
-
         $table = new xmldb_table('zoom');
 
         // Define and conditionally add field show_schedule.

--- a/exportical.php
+++ b/exportical.php
@@ -22,9 +22,9 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once(dirname(dirname(dirname(__FILE__))) . '/config.php');
+require_once(__DIR__ . '/../../config.php');
 require_once($CFG->libdir . '/moodlelib.php');
-require_once(dirname(__FILE__) . '/locallib.php');
+require_once(__DIR__ . '/locallib.php');
 require_once($CFG->libdir . '/bennu/bennu.inc.php');
 
 // Course_module ID.

--- a/exportical.php
+++ b/exportical.php
@@ -22,7 +22,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once(__DIR__ . '/../../config.php');
+require(__DIR__ . '/../../config.php');
 require_once($CFG->libdir . '/moodlelib.php');
 require_once(__DIR__ . '/locallib.php');
 require_once($CFG->libdir . '/bennu/bennu.inc.php');

--- a/exportical.php
+++ b/exportical.php
@@ -60,7 +60,7 @@ if ($zoom->recurring && $zoom->recurrence_type == ZOOM_RECURRINGTYPE_NOTIME) {
 }
 
 // Start ical file.
-$ical = new iCalendar;
+$ical = new iCalendar();
 $ical->add_property('method', 'PUBLISH');
 $ical->add_property('prodid', '-//Moodle Pty Ltd//NONSGML Moodle Version ' . $CFG->version . '//EN');
 

--- a/exportical.php
+++ b/exportical.php
@@ -22,10 +22,10 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once(dirname(dirname(dirname(__FILE__))).'/config.php');
+require_once(dirname(dirname(dirname(__FILE__))) . '/config.php');
 require_once($CFG->libdir . '/moodlelib.php');
-require_once(dirname(__FILE__).'/locallib.php');
-require_once($CFG->libdir.'/bennu/bennu.inc.php');
+require_once(dirname(__FILE__) . '/locallib.php');
+require_once($CFG->libdir . '/bennu/bennu.inc.php');
 
 // Course_module ID.
 $id = required_param('id', PARAM_INT);

--- a/exportical.php
+++ b/exportical.php
@@ -73,6 +73,7 @@ $descriptiontext = get_string('calendardescriptionURL', 'mod_zoom', $CFG->wwwroo
 if (!empty($convertedtext)) {
     $descriptiontext .= get_string('calendardescriptionintro', 'mod_zoom', $convertedtext);
 }
+
 if (!empty($meetinginvite)) {
     $descriptiontext .= "\n\n" . $meetinginvite;
 }

--- a/index.php
+++ b/index.php
@@ -22,10 +22,10 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once(dirname(dirname(dirname(__FILE__))).'/config.php');
-require_once(dirname(__FILE__).'/lib.php');
-require_once(dirname(__FILE__).'/locallib.php');
-require_once(dirname(__FILE__).'/../../lib/moodlelib.php');
+require_once(dirname(dirname(dirname(__FILE__))) . '/config.php');
+require_once(dirname(__FILE__) . '/lib.php');
+require_once(dirname(__FILE__) . '/locallib.php');
+require_once(dirname(__FILE__) . '/../../lib/moodlelib.php');
 
 $id = required_param('id', PARAM_INT); // Course.
 
@@ -89,7 +89,7 @@ $oldalign = ['left', 'left'];
 
 // Show section column if there are sections.
 if ($usesections) {
-    $strsectionname = get_string('sectionname', 'format_'.$course->format);
+    $strsectionname = get_string('sectionname', 'format_' . $course->format);
     array_unshift($newhead, $strsectionname);
     array_unshift($newalign, 'center');
     array_unshift($oldhead, $strsectionname);
@@ -136,7 +136,7 @@ foreach ($zooms as $z) {
         $displaytime = get_string('recurringmeeting', 'mod_zoom');
         $displaytime .= html_writer::empty_tag('br');
         if (($nextoccurrence = zoom_get_next_occurrence($z)) > 0) {
-            $displaytime .= get_string('nextoccurrence', 'mod_zoom').': '.userdate($nextoccurrence);
+            $displaytime .= get_string('nextoccurrence', 'mod_zoom') . ': ' . userdate($nextoccurrence);
         } else {
             $displaytime .= get_string('nooccurrenceleft', 'mod_zoom');
         }
@@ -191,7 +191,7 @@ if (has_capability('mod/zoom:refreshsessions', $context)) {
         'start' => date('Y-m-d', strtotime('-3 days')),
         'end' => date('Y-m-d'),
     ];
-    $url = new moodle_url($CFG->wwwroot. '/mod/zoom/console/get_meeting_report.php', $linkarguments);
+    $url = new moodle_url($CFG->wwwroot . '/mod/zoom/console/get_meeting_report.php', $linkarguments);
     echo html_writer::link($url, get_string('refreshreports', 'mod_zoom'), ['target' => '_blank', 'class' => 'pl-4']);
 }
 

--- a/index.php
+++ b/index.php
@@ -22,10 +22,10 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once(dirname(dirname(dirname(__FILE__))) . '/config.php');
-require_once(dirname(__FILE__) . '/lib.php');
-require_once(dirname(__FILE__) . '/locallib.php');
-require_once(dirname(__FILE__) . '/../../lib/moodlelib.php');
+require_once(__DIR__ . '/../../config.php');
+require_once(__DIR__ . '/lib.php');
+require_once(__DIR__ . '/locallib.php');
+require_once($CFG->libdir . '/moodlelib.php');
 
 $id = required_param('id', PARAM_INT); // Course.
 

--- a/index.php
+++ b/index.php
@@ -126,6 +126,7 @@ foreach ($zooms as $z) {
     if ($z->webinar) {
         $row[1] .= " ($strwebinar)";
     }
+
     // Get start time column information.
     if ($z->recurring && $z->recurrence_type == ZOOM_RECURRINGTYPE_NOTIME) {
         $displaytime = get_string('recurringmeeting', 'mod_zoom');
@@ -151,6 +152,7 @@ foreach ($zooms as $z) {
         if ($iszoommanager) {
             $row[3] = $sessions;
         }
+
         $oldtable->data[] = $row;
     } else {
         if ($inprogress) {
@@ -192,6 +194,7 @@ if (has_capability('mod/zoom:refreshsessions', $context)) {
     $url = new moodle_url($CFG->wwwroot. '/mod/zoom/console/get_meeting_report.php', $linkarguments);
     echo html_writer::link($url, get_string('refreshreports', 'mod_zoom'), ['target' => '_blank', 'class' => 'pl-4']);
 }
+
 echo html_writer::table($oldtable);
 
 echo $OUTPUT->footer();

--- a/index.php
+++ b/index.php
@@ -22,7 +22,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once(__DIR__ . '/../../config.php');
+require(__DIR__ . '/../../config.php');
 require_once(__DIR__ . '/lib.php');
 require_once(__DIR__ . '/locallib.php');
 require_once($CFG->libdir . '/moodlelib.php');

--- a/lib.php
+++ b/lib.php
@@ -470,7 +470,7 @@ function zoom_print_recent_activity($course, $viewfullnames, $timestart) {
  * @param int $groupid check for a particular group's activity only, defaults to 0 (all groups)
  * @todo implement this function
  */
-function zoom_get_recent_mod_activity(&$activities, &$index, $timestart, $courseid, $cmid, $userid=0, $groupid=0) {
+function zoom_get_recent_mod_activity(&$activities, &$index, $timestart, $courseid, $cmid, $userid = 0, $groupid = 0) {
 }
 
 /**
@@ -710,7 +710,7 @@ function zoom_scale_used_anywhere($scaleid) {
  * @param array $grades optional array/object of grade(s); 'reset' means reset grades in gradebook
  * @return void
  */
-function zoom_grade_item_update(stdClass $zoom, $grades=null) {
+function zoom_grade_item_update(stdClass $zoom, $grades = null) {
     global $CFG;
     require_once($CFG->libdir . '/gradelib.php');
 
@@ -937,7 +937,7 @@ function zoom_get_file_info($browser, $areas, $course, $cm, $context, $filearea,
  * @param bool $forcedownload whether or not force download
  * @param array $options additional options affecting the file serving
  */
-function zoom_pluginfile($course, $cm, $context, $filearea, array $args, $forcedownload, array $options=[]) {
+function zoom_pluginfile($course, $cm, $context, $filearea, array $args, $forcedownload, array $options = []) {
     if ($context->contextlevel != CONTEXT_MODULE) {
         send_file_not_found();
     }
@@ -973,7 +973,7 @@ function zoom_extend_navigation(navigation_node $navref, stdClass $course, stdCl
  * @param navigation_node $zoomnode zoom administration node
  * @todo implement this function
  */
-function zoom_extend_settings_navigation(settings_navigation $settingsnav, navigation_node $zoomnode=null) {
+function zoom_extend_settings_navigation(settings_navigation $settingsnav, navigation_node $zoomnode = null) {
 }
 
 /**

--- a/lib.php
+++ b/lib.php
@@ -1268,4 +1268,3 @@ function zoom_get_instance_breakout_rooms($zoomid) {
 
     return $breakoutrooms;
 }
-

--- a/lib.php
+++ b/lib.php
@@ -637,7 +637,7 @@ function zoom_populate_calender_item(stdClass $zoom, stdClass $occurrence = null
  */
 function zoom_calendar_item_delete(stdClass $zoom) {
     global $CFG, $DB;
-    require_once($CFG->dirroot.'/calendar/lib.php');
+    require_once($CFG->dirroot . '/calendar/lib.php');
 
     $events = $DB->get_records('event', [
         'modulename' => 'zoom',
@@ -712,7 +712,7 @@ function zoom_scale_used_anywhere($scaleid) {
  */
 function zoom_grade_item_update(stdClass $zoom, $grades=null) {
     global $CFG;
-    require_once($CFG->libdir.'/gradelib.php');
+    require_once($CFG->libdir . '/gradelib.php');
 
     $item = [];
     $item['itemname'] = clean_param($zoom->name, PARAM_NOTAGS);
@@ -752,7 +752,7 @@ function zoom_grade_item_update(stdClass $zoom, $grades=null) {
  */
 function zoom_grade_item_delete($zoom) {
     global $CFG;
-    require_once($CFG->libdir.'/gradelib.php');
+    require_once($CFG->libdir . '/gradelib.php');
 
     return grade_update('mod/zoom', $zoom->course, 'mod', 'zoom',
             $zoom->id, 0, null, ['deleted' => 1]);
@@ -768,7 +768,7 @@ function zoom_grade_item_delete($zoom) {
  */
 function zoom_update_grades(stdClass $zoom, $userid = 0) {
     global $CFG;
-    require_once($CFG->libdir.'/gradelib.php');
+    require_once($CFG->libdir . '/gradelib.php');
 
     // Populate array of grade objects indexed by userid.
     if ($zoom->grade == 0) {

--- a/lib.php
+++ b/lib.php
@@ -154,6 +154,7 @@ function zoom_update_instance(stdClass $zoom, mod_zoom_mod_form $mform = null) {
     if (isset($zoom->instance)) {
         $zoom->id = $zoom->instance;
     }
+
     $zoom->timemodified = time();
 
     // Deals with password manager issues.
@@ -225,6 +226,7 @@ function zoom_handle_weekly_days($zoom) {
             $weekdaynumbers[] = $i;
         }
     }
+
     return implode(',', $weekdaynumbers);
 }
 
@@ -240,6 +242,7 @@ function zoom_remove_weekly_options($data) {
         $key = 'weekly_days_' . $i;
         unset($data->$key);
     }
+
     return $data;
 }
 
@@ -280,14 +283,17 @@ function populate_zoom_from_response(stdClass $zoom, stdClass $response) {
             $newzoom->$field = $response->$field;
         }
     }
+
     if (isset($response->duration)) {
         $newzoom->duration = $response->duration * 60;
     }
+
     $newzoom->meeting_id = $response->id;
     $newzoom->name = $response->topic;
     if (isset($response->start_time)) {
         $newzoom->start_time = strtotime($response->start_time);
     }
+
     $recurringtypes = [
         ZOOM_RECURRING_MEETING,
         ZOOM_RECURRING_FIXED_MEETING,
@@ -304,30 +310,39 @@ function populate_zoom_from_response(stdClass $zoom, stdClass $response) {
             $newzoom->occurrences[] = $occurrence;
         }
     }
+
     if (isset($response->password)) {
         $newzoom->password = $response->password;
     }
+
     if (isset($response->settings->encryption_type)) {
         $newzoom->option_encryption_type = $response->settings->encryption_type;
     }
+
     if (isset($response->settings->join_before_host)) {
         $newzoom->option_jbh = $response->settings->join_before_host;
     }
+
     if (isset($response->settings->participant_video)) {
         $newzoom->option_participants_video = $response->settings->participant_video;
     }
+
     if (isset($response->settings->alternative_hosts)) {
         $newzoom->alternative_hosts = $response->settings->alternative_hosts;
     }
+
     if (isset($response->settings->mute_upon_entry)) {
         $newzoom->option_mute_upon_entry = $response->settings->mute_upon_entry;
     }
+
     if (isset($response->settings->meeting_authentication)) {
         $newzoom->option_authenticated_users = $response->settings->meeting_authentication;
     }
+
     if (isset($response->settings->waiting_room)) {
         $newzoom->option_waiting_room = $response->settings->waiting_room;
     }
+
     if (isset($response->settings->auto_recording)) {
         $newzoom->option_auto_recording = $response->settings->auto_recording;
     }
@@ -371,6 +386,7 @@ function zoom_delete_instance($id) {
     foreach ($meetinginstances as $meetinginstance) {
         $DB->delete_records('zoom_meeting_participants', ['detailsid' => $meetinginstance->id]);
     }
+
     $DB->delete_records('zoom_meeting_details', ['zoomid' => $zoom->id]);
 
     // Delete tracking field data for deleted meetings.
@@ -522,6 +538,7 @@ function zoom_calendar_item_update(stdClass $zoom) {
                     $changed = true;
                 }
             }
+
             if ($changed) {
                 calendar_event::load($event)->update($newevent);
             }
@@ -592,6 +609,7 @@ function zoom_populate_calender_item(stdClass $zoom, stdClass $occurrence = null
         $event->description = $zoom->intro;
         $event->format = $zoom->introformat;
     }
+
     if (!$occurrence) {
         $event->timesort = $zoom->start_time;
         $event->timestart = $zoom->start_time;
@@ -761,6 +779,7 @@ function zoom_update_grades(stdClass $zoom, $userid = 0) {
         if ($grade->grade == -1) {
             $grade->grade = null;
         }
+
         zoom_grade_item_update($zoom, $grade);
     } else if ($userid == 0) {
         $context = context_course::instance($zoom->course);
@@ -772,6 +791,7 @@ function zoom_update_grades(stdClass $zoom, $userid = 0) {
                 $grades[$k]->grade = null;
             }
         }
+
         zoom_grade_item_update($zoom, $grades);
     } else {
         zoom_grade_item_update($zoom);
@@ -990,6 +1010,7 @@ function mod_zoom_update_tracking_fields() {
                         } else {
                             $configvalue = $zoomtrackingfield[$zoomprop];
                         }
+
                         set_config($configname, $configvalue, 'zoom');
                     }
                 }
@@ -1093,7 +1114,6 @@ function zoom_build_instance_breakout_rooms_array_for_api($zoom) {
     $breakoutrooms = [];
     if (!empty($zoom->rooms)) {
         foreach ($zoom->rooms as $roomid => $roomname) {
-
             // Getting meeting rooms participants.
             $roomparticipants = [];
             $dbroomparticipants = [];
@@ -1117,6 +1137,7 @@ function zoom_build_instance_breakout_rooms_array_for_api($zoom) {
                         $dbroomgroupsmembers[] = $groupid;
                     }
                 }
+
                 $roomgroupsmembers = array_merge(...$roomgroupsmembers);
             }
 

--- a/lib.php
+++ b/lib.php
@@ -43,7 +43,7 @@ function zoom_supports($feature) {
         return MOD_PURPOSE_COMMUNICATION;
     }
 
-    switch($feature) {
+    switch ($feature) {
         case FEATURE_BACKUP_MOODLE2:
         case FEATURE_COMPLETION_TRACKS_VIEWS:
         case FEATURE_GRADE_HAS_GRADE:

--- a/loadmeeting.php
+++ b/loadmeeting.php
@@ -22,9 +22,10 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-// phpcs:ignore moodle.Files.RequireLogin.Missing
-require_once(dirname(dirname(__DIR__)) . '/config.php');
+require_once(__DIR__ . '/../../config.php');
 require_once(__DIR__ . '/locallib.php');
+
+require_login();
 
 // Course_module ID.
 $id = required_param('id', PARAM_INT);
@@ -32,7 +33,7 @@ if ($id) {
     $context = context_module::instance($id);
     $PAGE->set_context($context);
 
-    // Call load meeting function (note: this is where require_login() happens).
+    // Call load meeting function (note: this is where additional access checks happen).
     $meetinginfo = zoom_load_meeting($id, $context);
 
     // Redirect if available, otherwise deny access.

--- a/loadmeeting.php
+++ b/loadmeeting.php
@@ -22,7 +22,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once(__DIR__ . '/../../config.php');
+require(__DIR__ . '/../../config.php');
 require_once(__DIR__ . '/locallib.php');
 
 require_login();

--- a/loadrecording.php
+++ b/loadrecording.php
@@ -23,7 +23,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once(__DIR__ . '/../../config.php');
+require(__DIR__ . '/../../config.php');
 require_once($CFG->libdir . '/moodlelib.php');
 require_once(__DIR__ . '/locallib.php');
 

--- a/locallib.php
+++ b/locallib.php
@@ -969,7 +969,7 @@ function zoom_helper_icalendar_event($event, $description) {
     $hostaddress = str_replace('https://', '', $hostaddress);
     $uid = $event->id . '@' . $hostaddress;
 
-    $icalevent = new iCalendar_event;
+    $icalevent = new iCalendar_event();
     $icalevent->add_property('uid', $uid); // A unique identifier.
     $icalevent->add_property('summary', $event->name); // Title.
     $icalevent->add_property('dtstamp', Bennu::timestamp_to_datetime()); // Time of creation.

--- a/locallib.php
+++ b/locallib.php
@@ -254,10 +254,12 @@ function zoom_fatal_error($errorcode, $module='', $continuelink='', $a=null) {
             $debuginfo = str_replace("\n", '<br />', $debuginfo); // Keep newlines.
             $output .= $OUTPUT->notification('<strong>Debug info:</strong> '.$debuginfo, 'notifytiny');
         }
+
         if (!empty($backtrace)) {
             $output .= $OUTPUT->notification('<strong>Stack trace:</strong> '.format_backtrace($backtrace), 'notifytiny');
         }
-        if ($obbuffer !== '' ) {
+
+        if ($obbuffer !== '') {
             $output .= $OUTPUT->notification('<strong>Output buffer:</strong> '.s($obbuffer), 'notifytiny');
         }
     }
@@ -339,6 +341,7 @@ function zoom_get_sessions_for_display($zoomid) {
                     $uniquevalues[$participant->uuid] = true;
                 }
             }
+
             if ($participant->userid != null) {
                 if (!$unique || !array_key_exists($participant->userid, $uniquevalues)) {
                     $uniquevalues[$participant->userid] = true;
@@ -346,6 +349,7 @@ function zoom_get_sessions_for_display($zoomid) {
                     $unique = false;
                 }
             }
+
             if ($participant->user_email != null) {
                 if (!$unique || !array_key_exists($participant->user_email, $uniquevalues)) {
                     $uniquevalues[$participant->user_email] = true;
@@ -353,6 +357,7 @@ function zoom_get_sessions_for_display($zoomid) {
                     $unique = false;
                 }
             }
+
             $uniqueparticipantcount += $unique ? 1 : 0;
         }
 
@@ -362,6 +367,7 @@ function zoom_get_sessions_for_display($zoomid) {
         $sessions[$uuid]['starttime'] = userdate($instance->start_time, $format);
         $sessions[$uuid]['endtime'] = userdate($instance->start_time + $instance->duration * 60, $format);
     }
+
     return $sessions;
 }
 
@@ -937,6 +943,7 @@ function zoom_get_api_identifier($user) {
         // If one of the custom user fields.
         $identifier = $user->profile[$field];
     }
+
     if (empty($identifier)) {
         // Fallback to email if the field is not set.
         $identifier = $user->email;
@@ -1055,6 +1062,7 @@ function zoom_load_meeting($id, $context, $usestarturl = true) {
         if ($userisregistered) {
             $url = $registrantjoinurl;
         }
+
         $returns['nexturl'] = new moodle_url($url, ['uname' => fullname($USER)]);
     }
 
@@ -1181,6 +1189,7 @@ function zoom_sync_meeting_tracking_fields($zoomid, $trackingfields) {
     foreach ($tfrows as $tfrow) {
         $tfobjects[$tfrow->tracking_field] = $tfrow;
     }
+
     $defaulttrackingfields = zoom_clean_tracking_fields();
     foreach ($defaulttrackingfields as $key => $defaulttrackingfield) {
         $value = $tfvalues[$key] ?? '';
@@ -1234,11 +1243,13 @@ function zoom_get_meeting_recordings($zoomid = null) {
     if ($zoomid !== null) {
         $params['zoomid'] = $zoomid;
     }
+
     $records = $DB->get_records('zoom_meeting_recordings', $params);
     $recordings = [];
     foreach ($records as $recording) {
         $recordings[$recording->zoomrecordingid] = $recording;
     }
+
     return $recordings;
 }
 
@@ -1256,11 +1267,13 @@ function zoom_get_meeting_recordings_grouped($zoomid = null) {
     if ($zoomid !== null) {
         $params['zoomid'] = $zoomid;
     }
+
     $records = $DB->get_records('zoom_meeting_recordings', $params, 'recordingstart ASC');
     $recordings = [];
     foreach ($records as $recording) {
         $recordings[$recording->meetinguuid][$recording->zoomrecordingid] = $recording;
     }
+
     return $recordings;
 }
 
@@ -1353,5 +1366,6 @@ function zoom_get_registrant_join_url($useremail, $meetingid, $iswebinar) {
             }
         }
     }
+
     return false;
 }

--- a/locallib.php
+++ b/locallib.php
@@ -28,8 +28,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
-require_once($CFG->dirroot.'/mod/zoom/lib.php');
-require_once($CFG->dirroot.'/mod/zoom/classes/webservice.php');
+require_once($CFG->dirroot . '/mod/zoom/lib.php');
+require_once($CFG->dirroot . '/mod/zoom/classes/webservice.php');
 
 // Constants.
 // Audio options.
@@ -252,15 +252,15 @@ function zoom_fatal_error($errorcode, $module='', $continuelink='', $a=null) {
         if (!empty($debuginfo)) {
             $debuginfo = s($debuginfo); // Removes all nasty JS.
             $debuginfo = str_replace("\n", '<br />', $debuginfo); // Keep newlines.
-            $output .= $OUTPUT->notification('<strong>Debug info:</strong> '.$debuginfo, 'notifytiny');
+            $output .= $OUTPUT->notification('<strong>Debug info:</strong> ' . $debuginfo, 'notifytiny');
         }
 
         if (!empty($backtrace)) {
-            $output .= $OUTPUT->notification('<strong>Stack trace:</strong> '.format_backtrace($backtrace), 'notifytiny');
+            $output .= $OUTPUT->notification('<strong>Stack trace:</strong> ' . format_backtrace($backtrace), 'notifytiny');
         }
 
         if ($obbuffer !== '') {
-            $output .= $OUTPUT->notification('<strong>Output buffer:</strong> '.s($obbuffer), 'notifytiny');
+            $output .= $OUTPUT->notification('<strong>Output buffer:</strong> ' . s($obbuffer), 'notifytiny');
         }
     }
 
@@ -316,7 +316,7 @@ function zoom_get_instance_setup() {
  * @return array information about the meeting
  */
 function zoom_get_sessions_for_display($zoomid) {
-    require_once(__DIR__.'/../../lib/moodlelib.php');
+    require_once(__DIR__ . '/../../lib/moodlelib.php');
     global $DB;
 
     $sessions = [];
@@ -726,7 +726,7 @@ function zoom_get_users_from_alternativehosts(array $alternativehosts) {
     list($insql, $inparams) = $DB->get_in_or_equal($alternativehosts);
     $sql = 'SELECT *
             FROM {user}
-            WHERE email '.$insql.'
+            WHERE email ' . $insql . '
             ORDER BY lastname ASC';
     $alternativehostusers = $DB->get_records_sql($sql, $inparams);
 
@@ -748,7 +748,7 @@ function zoom_get_nonusers_from_alternativehosts(array $alternativehosts) {
     list($insql, $inparams) = $DB->get_in_or_equal($alternativehosts);
     $sql = 'SELECT email
             FROM {user}
-            WHERE email '.$insql.'
+            WHERE email ' . $insql . '
             ORDER BY email ASC';
     $alternativehostusersmails = $DB->get_records_sql($sql, $inparams);
     foreach ($alternativehosts as $ah) {
@@ -862,7 +862,7 @@ function zoom_get_eligible_meeting_participants(context $context) {
     // Compose SQL query.
     $sqlsnippets = get_enrolled_with_capabilities_join($context, '', 'mod/zoom:view', 0, true);
     $sql = 'SELECT count(DISTINCT u.id)
-            FROM {user} u '.$sqlsnippets->joins.' WHERE '.$sqlsnippets->wheres;
+            FROM {user} u ' . $sqlsnippets->joins . ' WHERE ' . $sqlsnippets->wheres;
 
     // Run query and count records.
     $eligibleparticipantcount = $DB->count_records_sql($sql, $sqlsnippets->params);

--- a/locallib.php
+++ b/locallib.php
@@ -316,8 +316,9 @@ function zoom_get_instance_setup() {
  * @return array information about the meeting
  */
 function zoom_get_sessions_for_display($zoomid) {
-    require_once(__DIR__ . '/../../lib/moodlelib.php');
-    global $DB;
+    global $DB, $CFG;
+
+    require_once($CFG->libdir . '/moodlelib.php');
 
     $sessions = [];
     $format = get_string('strftimedatetimeshort', 'langconfig');

--- a/locallib.php
+++ b/locallib.php
@@ -228,7 +228,7 @@ class zoom_api_limit_exception extends moodle_exception {
  *                             the site index page.
  * @param mixed $a Extra words and phrases that might be required in the error string
  */
-function zoom_fatal_error($errorcode, $module='', $continuelink='', $a=null) {
+function zoom_fatal_error($errorcode, $module = '', $continuelink = '', $a = null) {
     global $CFG, $COURSE, $OUTPUT, $PAGE;
 
     $output = '';

--- a/mod_form.php
+++ b/mod_form.php
@@ -89,6 +89,7 @@ class mod_zoom_mod_form extends moodleform_mod {
                     // use true to avoid a service call.
                     $currenthostschedulers[$this->current->host_id] = true;
                 }
+
                 $canschedule = array_intersect_key($canschedule, $currenthostschedulers);
             }
 
@@ -101,10 +102,12 @@ class mod_zoom_mod_form extends moodleform_mod {
                 if (isset($scheduleusers[$zoomemail])) {
                     continue;
                 }
+
                 if ($zoomemail === strtolower($USER->email)) {
                     $scheduleusers[$zoomemail] = get_string('scheduleforself', 'zoom');
                     continue;
                 }
+
                 foreach ($moodleusers as $muser) {
                     if ($zoomemail === strtolower($muser->email)) {
                         $scheduleusers[$zoomemail] = fullname($muser);
@@ -205,6 +208,7 @@ class mod_zoom_mod_form extends moodleform_mod {
         for ($i = 1; $i <= 90; $i++) {
             $options[$i] = $i;
         }
+
         $group = [];
         $group[] = $mform->createElement('select', 'repeat_interval', '', $options);
         $htmlspantextstart = '<span class="repeat_interval" id="interval_';
@@ -225,6 +229,7 @@ class mod_zoom_mod_form extends moodleform_mod {
             $group[] = $mform->createElement('advcheckbox', $weekdayid, '',
                 $weekday, null, [0, $key]);
         }
+
         $mform->addGroup($group, 'weekly_days_group', get_string('occurson', 'zoom'), ' ', false);
         $mform->hideif('weekly_days_group', 'recurrence_type', 'noteq', ZOOM_RECURRINGTYPE_WEEKLY);
         $mform->hideif('weekly_days_group', 'recurring', 'notchecked');
@@ -241,6 +246,7 @@ class mod_zoom_mod_form extends moodleform_mod {
         for ($i = 1; $i <= 31; $i++) {
             $monthoptions[$i] = $i;
         }
+
         $monthlyweekoptions = zoom_get_monthweek_options();
 
         $group = [];
@@ -267,6 +273,7 @@ class mod_zoom_mod_form extends moodleform_mod {
         for ($i = 1; $i <= 50; $i++) {
             $maxoptions[$i] = $i;
         }
+
         $group = [];
         $group[] = $mform->createElement(
             'radio',
@@ -311,6 +318,7 @@ class mod_zoom_mod_form extends moodleform_mod {
                     if (!$haswebinarlicense) {
                         $webinarattr = ['disabled' => true, 'group' => null];
                     }
+
                     $mform->addElement('advcheckbox', 'webinar', get_string('webinar', 'zoom'),
                             get_string('webinarthisis', 'zoom'), $webinarattr);
                     $mform->setDefault('webinar', $config->webinardefault);
@@ -337,6 +345,7 @@ class mod_zoom_mod_form extends moodleform_mod {
                     $mform->addElement('static', $key . '_recommended_values', null,
                         get_string('trackingfields_recommendedvalues', 'mod_zoom') . $config->$rvprop);
                 }
+
                 $requiredproperty = 'tf_' . $key . '_required';
                 if (!empty($config->$requiredproperty)) {
                     $mform->addRule($key, null, 'required', null, 'client');
@@ -430,6 +439,7 @@ class mod_zoom_mod_form extends moodleform_mod {
         } else {
             $mform->setDefault('requirepasscode', 1);
         }
+
         $mform->addHelpButton('requirepasscode', 'requirepasscode', 'zoom');
 
         // Set default passcode and description from Zoom security settings.
@@ -471,6 +481,7 @@ class mod_zoom_mod_form extends moodleform_mod {
                     $encryptionattr = ['disabled' => true];
                     $defaultencryptiontype = ZOOM_ENCRYPTION_TYPE_ENHANCED;
                 }
+
                 $mform->addGroup([
                         $mform->createElement('radio', 'option_encryption_type', '',
                                 get_string('option_encryption_type_enhancedencryption', 'zoom'),
@@ -483,6 +494,7 @@ class mod_zoom_mod_form extends moodleform_mod {
                 $mform->addHelpButton('option_encryption_type_group', 'option_encryption_type', 'zoom');
                 $mform->disabledIf('option_encryption_type_group', 'webinar', 'checked');
             }
+
             $mform->setType('option_encryption_type', PARAM_ALPHANUMEXT);
         }
 
@@ -590,7 +602,6 @@ class mod_zoom_mod_form extends moodleform_mod {
         $this->showschedulingprivilege = $showschedulingprivilege;
         $showalternativehosts = ($config->showalternativehosts != ZOOM_ALTERNATIVEHOSTS_DISABLE);
         if ($showschedulingprivilege || $showalternativehosts) {
-
             // Adding the "host" fieldset, where all settings relating to defining the meeting host are shown.
             $mform->addElement('header', 'general', get_string('host', 'mod_zoom'));
 
@@ -645,6 +656,7 @@ class mod_zoom_mod_form extends moodleform_mod {
                 } else {
                     $mform->setDefault('schedule_for', strtolower(zoom_get_api_identifier($USER)));
                 }
+
                 $mform->addHelpButton('schedule_for', 'schedulefor', 'zoom');
 
                 if ($allowrecordingchangeoption) {
@@ -819,11 +831,13 @@ class mod_zoom_mod_form extends moodleform_mod {
                 unset($data->end_times);
                 unset($data->end_date_time);
             }
+
             // If weekly recurring is not selected, unset weekly options.
             if ($data->recurrence_type != ZOOM_RECURRINGTYPE_WEEKLY) {
                 // Unset the weekly fields.
                 $data = zoom_remove_weekly_options($data);
             }
+
             // If monthly recurring is not selected, unset monthly options.
             if ($data->recurrence_type != ZOOM_RECURRINGTYPE_MONTHLY) {
                 // Unset the weekly fields.
@@ -947,6 +961,7 @@ class mod_zoom_mod_form extends moodleform_mod {
                     break;
                 }
             }
+
             if (!$scheduleok) {
                 $errors['schedule_for'] = get_string('invalidscheduleuser', 'mod_zoom');
             }
@@ -1001,9 +1016,11 @@ class mod_zoom_mod_form extends moodleform_mod {
                         $weekdaynumbers[] = $i;
                     }
                 }
+
                 if (empty($weekdaynumbers)) {
                     $errors['weekly_days_group'] = get_string('err_weekly_days', 'zoom');
                 }
+
                 // For weekly, maximum is 12 weeks.
                 if ($data['repeat_interval'] > 12) {
                     $errors['repeat_group'] = get_string('err_repeat_weekly_interval', 'zoom');
@@ -1021,6 +1038,7 @@ class mod_zoom_mod_form extends moodleform_mod {
                 if ($data['end_date_time'] < time()) {
                     $errors['radioenddate'] = get_string('err_end_date', 'zoom');
                 }
+
                 if ($data['end_date_time'] < $data['start_time']) {
                     $errors['radioenddate'] = get_string('err_end_date_before_start', 'zoom');
                 }

--- a/mod_form.php
+++ b/mod_form.php
@@ -27,9 +27,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->dirroot.'/course/moodleform_mod.php');
-require_once($CFG->dirroot.'/mod/zoom/lib.php');
-require_once($CFG->dirroot.'/mod/zoom/locallib.php');
+require_once($CFG->dirroot . '/course/moodleform_mod.php');
+require_once($CFG->dirroot . '/mod/zoom/lib.php');
+require_once($CFG->dirroot . '/mod/zoom/locallib.php');
 
 /**
  * Module instance settings form

--- a/participants.php
+++ b/participants.php
@@ -21,14 +21,14 @@
  * @copyright  2015 UC Regents
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-// Login check require_login() is called in zoom_get_instance_setup();.
-// @codingStandardsIgnoreLine
-require_once(dirname(dirname(dirname(__FILE__))).'/config.php');
-require_once(dirname(__FILE__) . '/lib.php');
-require_once(dirname(__FILE__) . '/locallib.php');
-require_once(dirname(__FILE__) . '/../../lib/accesslib.php');
-require_once(dirname(__FILE__) . '/../../lib/moodlelib.php');
+require_once(__DIR__ . '/../../config.php');
+require_once(__DIR__ . '/lib.php');
+require_once(__DIR__ . '/locallib.php');
+require_once($CFG->libdir . '/accesslib.php');
+require_once($CFG->libdir . '/moodlelib.php');
 
+require_login();
+// Additional access checks in zoom_get_instance_setup().
 list($course, $cm, $zoom) = zoom_get_instance_setup();
 
 global $DB;
@@ -172,7 +172,7 @@ if ($export != 'xls') {
 
     echo $OUTPUT->footer();
 } else {
-    require_once(dirname(__FILE__) . '/../../lib/excellib.class.php');
+    require_once($CFG->libdir . '/excellib.class.php');
 
     $workbook = new MoodleExcelWorkbook("zoom_participants_{$zoom->meeting_id}");
     $worksheet = $workbook->add_worksheet($strtitle);

--- a/participants.php
+++ b/participants.php
@@ -184,14 +184,16 @@ if ($export != 'xls') {
         $worksheet->write_string($row, $col++, $colname, $boldformat);
     }
 
-    $row++; $col = 0;
+    $row++;
+    $col = 0;
 
     foreach ($table->data as $entry) {
         foreach ($entry as $value) {
             $worksheet->write_string($row, $col++, $value);
         }
 
-        $row++; $col = 0;
+        $row++;
+        $col = 0;
     }
 
     $workbook->close();

--- a/participants.php
+++ b/participants.php
@@ -152,6 +152,7 @@ foreach ($participants as $p) {
     if ($durationremainder != 0) {
         $p->duration += 60 - $durationremainder;
     }
+
     $row[] = $p->duration / 60;
 
     $table->data[] = $row;
@@ -182,12 +183,14 @@ if ($export != 'xls') {
     foreach ($table->head as $colname) {
         $worksheet->write_string($row, $col++, $colname, $boldformat);
     }
+
     $row++; $col = 0;
 
     foreach ($table->data as $entry) {
         foreach ($entry as $value) {
             $worksheet->write_string($row, $col++, $value);
         }
+
         $row++; $col = 0;
     }
 

--- a/participants.php
+++ b/participants.php
@@ -21,7 +21,7 @@
  * @copyright  2015 UC Regents
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-require_once(__DIR__ . '/../../config.php');
+require(__DIR__ . '/../../config.php');
 require_once(__DIR__ . '/lib.php');
 require_once(__DIR__ . '/locallib.php');
 require_once($CFG->libdir . '/accesslib.php');

--- a/participants.php
+++ b/participants.php
@@ -24,10 +24,10 @@
 // Login check require_login() is called in zoom_get_instance_setup();.
 // @codingStandardsIgnoreLine
 require_once(dirname(dirname(dirname(__FILE__))).'/config.php');
-require_once(dirname(__FILE__).'/lib.php');
-require_once(dirname(__FILE__).'/locallib.php');
-require_once(dirname(__FILE__).'/../../lib/accesslib.php');
-require_once(dirname(__FILE__).'/../../lib/moodlelib.php');
+require_once(dirname(__FILE__) . '/lib.php');
+require_once(dirname(__FILE__) . '/locallib.php');
+require_once(dirname(__FILE__) . '/../../lib/accesslib.php');
+require_once(dirname(__FILE__) . '/../../lib/moodlelib.php');
 
 list($course, $cm, $zoom) = zoom_get_instance_setup();
 
@@ -172,7 +172,7 @@ if ($export != 'xls') {
 
     echo $OUTPUT->footer();
 } else {
-    require_once(dirname(__FILE__).'/../../lib/excellib.class.php');
+    require_once(dirname(__FILE__) . '/../../lib/excellib.class.php');
 
     $workbook = new MoodleExcelWorkbook("zoom_participants_{$zoom->meeting_id}");
     $worksheet = $workbook->add_worksheet($strtitle);

--- a/recordings.php
+++ b/recordings.php
@@ -94,9 +94,11 @@ if (empty($recordings)) {
                 if (empty($recordingdate)) {
                     $recordingdate = date('F j, Y, g:i:s a \P\T', $recording->recordingstart);
                 }
+
                 if (empty($recordingpasscode)) {
                     $recordingpasscode = $recording->passcode;
                 }
+
                 if ($iszoommanager && empty($recordingshowhtml)) {
                     $isrecordinghidden = intval($recording->showrecording) === 0;
                     $urlparams = [
@@ -112,12 +114,14 @@ if (empty($recordings)) {
                     if ($isrecordinghidden) {
                         $recordingshowtext = get_string('recordingshow', 'mod_zoom');
                     }
+
                     $btnclass = 'btn btn-';
                     $btnclass .= $isrecordinghidden ? 'dark' : 'primary';
                     $recordingshowbutton = html_writer::div($recordingshowtext, $btnclass);
                     $recordingshowbuttonhtml = html_writer::link($recordingshowurl, $recordingshowbutton);
                     $recordingshowhtml = html_writer::div($recordingshowbuttonhtml);
                 }
+
                 $params = ['id' => $cm->id, 'recordingid' => $recording->id];
                 $recordingurl = new moodle_url('/mod/zoom/loadrecording.php', $params);
                 $recordinglink = html_writer::link($recordingurl, $recording->name);
@@ -125,6 +129,7 @@ if (empty($recordings)) {
                 $recordinghtml .= html_writer::div($recordinglinkhtml, 'recording', ['style' => 'margin-bottom:.5rem']);
             }
         }
+
         // Output only one row per grouping.
         $table->data[] = [$recordingdate, $recordinghtml, $recordingpasscode, $recordingshowhtml];
     }

--- a/recordings.php
+++ b/recordings.php
@@ -23,7 +23,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once(__DIR__ . '/../../config.php');
+require(__DIR__ . '/../../config.php');
 require_once(__DIR__ . '/lib.php');
 require_once(__DIR__ . '/locallib.php');
 

--- a/recreate.php
+++ b/recreate.php
@@ -24,8 +24,8 @@
 // Login check require_login() is called in zoom_get_instance_setup();.
 // @codingStandardsIgnoreLine
 require_once(dirname(dirname(dirname(__FILE__))).'/config.php');
-require_once(dirname(__FILE__).'/lib.php');
-require_once(dirname(__FILE__).'/locallib.php');
+require_once(dirname(__FILE__) . '/lib.php');
+require_once(dirname(__FILE__) . '/locallib.php');
 
 list($course, $cm, $zoom) = zoom_get_instance_setup();
 

--- a/recreate.php
+++ b/recreate.php
@@ -21,7 +21,7 @@
  * @copyright  2017 UC Regents
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-require_once(__DIR__ . '/../../config.php');
+require(__DIR__ . '/../../config.php');
 require_once(__DIR__ . '/lib.php');
 require_once(__DIR__ . '/locallib.php');
 

--- a/recreate.php
+++ b/recreate.php
@@ -21,12 +21,12 @@
  * @copyright  2017 UC Regents
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-// Login check require_login() is called in zoom_get_instance_setup();.
-// @codingStandardsIgnoreLine
-require_once(dirname(dirname(dirname(__FILE__))).'/config.php');
-require_once(dirname(__FILE__) . '/lib.php');
-require_once(dirname(__FILE__) . '/locallib.php');
+require_once(__DIR__ . '/../../config.php');
+require_once(__DIR__ . '/lib.php');
+require_once(__DIR__ . '/locallib.php');
 
+require_login();
+// Additional access checks in zoom_get_instance_setup().
 list($course, $cm, $zoom) = zoom_get_instance_setup();
 
 require_sesskey();

--- a/report.php
+++ b/report.php
@@ -76,7 +76,6 @@ if (!empty($sessions)) {
                          . get_string('participantdatanotavailable', 'mod_zoom')
                          . '] '
                          . $OUTPUT->help_icon('participantdatanotavailable', 'mod_zoom');
-
             } else {
                 $url = new moodle_url('/mod/zoom/participants.php', ['id' => $cm->id, 'uuid' => $uuid]);
                 $row[] = html_writer::link($url, $meet['count']);

--- a/report.php
+++ b/report.php
@@ -21,14 +21,14 @@
  * @copyright  2015 UC Regents
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-// Login check require_login() is called in zoom_get_instance_setup();.
-// @codingStandardsIgnoreLine
-require_once(dirname(dirname(dirname(__FILE__))).'/config.php');
-require_once(dirname(__FILE__) . '/lib.php');
-require_once(dirname(__FILE__) . '/locallib.php');
-require_once(dirname(__FILE__) . '/mod_form.php');
-require_once(dirname(__FILE__) . '/../../lib/moodlelib.php');
+require_once(__DIR__ . '/../../config.php');
+require_once(__DIR__ . '/lib.php');
+require_once(__DIR__ . '/locallib.php');
+require_once(__DIR__ . '/mod_form.php');
+require_once($CFG->libdir . '/moodlelib.php');
 
+require_login();
+// Additional access checks in zoom_get_instance_setup().
 list($course, $cm, $zoom) = zoom_get_instance_setup();
 
 // Check capability.

--- a/report.php
+++ b/report.php
@@ -24,10 +24,10 @@
 // Login check require_login() is called in zoom_get_instance_setup();.
 // @codingStandardsIgnoreLine
 require_once(dirname(dirname(dirname(__FILE__))).'/config.php');
-require_once(dirname(__FILE__).'/lib.php');
-require_once(dirname(__FILE__).'/locallib.php');
-require_once(dirname(__FILE__).'/mod_form.php');
-require_once(dirname(__FILE__).'/../../lib/moodlelib.php');
+require_once(dirname(__FILE__) . '/lib.php');
+require_once(dirname(__FILE__) . '/locallib.php');
+require_once(dirname(__FILE__) . '/mod_form.php');
+require_once(dirname(__FILE__) . '/../../lib/moodlelib.php');
 
 list($course, $cm, $zoom) = zoom_get_instance_setup();
 

--- a/report.php
+++ b/report.php
@@ -21,7 +21,7 @@
  * @copyright  2015 UC Regents
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-require_once(__DIR__ . '/../../config.php');
+require(__DIR__ . '/../../config.php');
 require_once(__DIR__ . '/lib.php');
 require_once(__DIR__ . '/locallib.php');
 require_once(__DIR__ . '/mod_form.php');

--- a/settings.php
+++ b/settings.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->dirroot.'/mod/zoom/locallib.php');
+require_once($CFG->dirroot . '/mod/zoom/locallib.php');
 require_once($CFG->libdir . '/environmentlib.php');
 
 if ($ADMIN->fulltree) {
@@ -153,7 +153,7 @@ if ($ADMIN->fulltree) {
     } else {
         $displayleadtime = new admin_setting_configcheckbox('zoom/displayleadtime',
                 get_string('displayleadtime', 'mod_zoom'),
-                get_string('displayleadtime_desc', 'mod_zoom') . '<br />'.
+                get_string('displayleadtime_desc', 'mod_zoom') . '<br />' .
                         get_string('displayleadtime_nohideif', 'mod_zoom', get_string('firstjoin', 'mod_zoom')),
                 0, 1, 0);
         $settings->add($displayleadtime);

--- a/settings.php
+++ b/settings.php
@@ -46,6 +46,7 @@ if ($ADMIN->fulltree) {
             $status = 'connectionfailed';
             $errormessage = $error->a;
         }
+
         $statusmessage = $OUTPUT->notification(get_string('connectionstatus', 'mod_zoom') .
                 ': ' . get_string($status, 'mod_zoom') . $errormessage, $notifyclass);
         $connectionstatus = new admin_setting_heading('zoom/connectionstatus', $statusmessage, '');
@@ -137,6 +138,7 @@ if ($ADMIN->fulltree) {
     foreach ($jointimechoices as $minutes) {
         $jointimeselect[$minutes] = $minutes . ' ' . get_string('mins');
     }
+
     $firstabletojoin = new admin_setting_configselect('zoom/firstabletojoin',
             get_string('firstjoin', 'mod_zoom'), get_string('firstjoin_desc', 'mod_zoom'),
             15, $jointimeselect);
@@ -386,6 +388,7 @@ if ($ADMIN->fulltree) {
         $invitationregexhelp .= "\n\n" . get_string('invitationregex_nohideif', 'mod_zoom',
                                                         get_string('invitationregexenabled', 'mod_zoom'));
     }
+
     $settings->add(new admin_setting_heading('zoom/invitationregex',
             get_string('invitationregex', 'mod_zoom'), $invitationregexhelp));
 

--- a/showrecording.php
+++ b/showrecording.php
@@ -23,7 +23,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once(__DIR__ . '/../../config.php');
+require(__DIR__ . '/../../config.php');
 require_once($CFG->libdir . '/moodlelib.php');
 require_once(__DIR__ . '/locallib.php');
 

--- a/tests/advanced_passcode_test.php
+++ b/tests/advanced_passcode_test.php
@@ -31,7 +31,6 @@ use mod_zoom_webservice;
  * PHPunit testcase class.
  */
 class advanced_passcode_test extends basic_testcase {
-
     /**
      * Fake data from get_user_security_settings().
      * @var object

--- a/tests/error_handling_test.php
+++ b/tests/error_handling_test.php
@@ -31,7 +31,6 @@ use zoom_not_found_exception;
  * PHPunit testcase class.
  */
 class error_handling_test extends basic_testcase {
-
     /**
      * Exception for when the meeting isn't found on Zoom.
      * @var zoom_not_found_exception

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -66,6 +66,7 @@ class mod_zoom_generator extends testing_module_generator {
                 $record->{$name} = $value;
             }
         }
+
         return parent::create_instance($record, $options);
     }
 }

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -31,7 +31,7 @@ class mod_zoom_generator extends testing_module_generator {
      */
     public function create_instance($record = null, array $options = null) {
         global $CFG;
-        require_once($CFG->dirroot.'/mod/zoom/locallib.php');
+        require_once($CFG->dirroot . '/mod/zoom/locallib.php');
 
         set_config('clientid', 'test', 'zoom');
         set_config('clientsecret', 'test', 'zoom');

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -22,7 +22,6 @@
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class mod_zoom_generator extends testing_module_generator {
-
     /**
      * Creates new Zoom module instance.
      * @param array|stdClass $record

--- a/tests/get_meeting_reports_test.php
+++ b/tests/get_meeting_reports_test.php
@@ -33,7 +33,6 @@ use stdClass;
  * @covers \mod_zoom\task\get_meeting_reports
  */
 class get_meeting_reports_test extends advanced_testcase {
-
     /**
      * Scheduled task object.
      * @var \mod_zoom\task\get_meeting_reports

--- a/tests/get_meeting_reports_test.php
+++ b/tests/get_meeting_reports_test.php
@@ -222,6 +222,7 @@ class get_meeting_reports_test extends advanced_testcase {
         foreach ($users as $user) {
             $this->getDataGenerator()->enrol_user($user->id, $course->id);
         }
+
         list($names, $emails) = $this->meetingtask->get_enrollments($course->id);
 
         // 1) Make sure we match someone with middle name missing.

--- a/tests/get_meeting_reports_test.php
+++ b/tests/get_meeting_reports_test.php
@@ -98,7 +98,8 @@ class get_meeting_reports_test extends advanced_testcase {
      * Make sure that format_participant() can match Moodle users.
      */
     public function test_format_participant_matching() {
-        global $DB;return;
+        global $DB;
+        return;
 
         // 1) If user does not match, verify that we are using data from Zoom.
         $participant = $this->meetingtask->format_participant($this->zoomdata,

--- a/tests/mod_zoom_grade_test.php
+++ b/tests/mod_zoom_grade_test.php
@@ -30,7 +30,6 @@ use advanced_testcase;
  * PHPunit testcase class.
  */
 class mod_zoom_grade_test extends advanced_testcase {
-
     /**
      * Setup to ensure that fixtures are loaded.
      */

--- a/tests/mod_zoom_invitation_test.php
+++ b/tests/mod_zoom_invitation_test.php
@@ -35,7 +35,6 @@ use moodle_url;
  * @covers \mod_zoom\invitation
  */
 class mod_zoom_invitation_test extends advanced_testcase {
-
     /**
      * Setup to ensure that fixtures are loaded.
      */

--- a/tests/mod_zoom_webservice_test.php
+++ b/tests/mod_zoom_webservice_test.php
@@ -34,7 +34,6 @@ use zoom_api_retry_failed_exception;
  * @covers \mod_zoom_webservice
  */
 class mod_zoom_webservice_test extends advanced_testcase {
-
     /**
      * Setup to ensure that fixtures are loaded.
      */

--- a/tests/mod_zoom_webservice_test.php
+++ b/tests/mod_zoom_webservice_test.php
@@ -130,6 +130,7 @@ class mod_zoom_webservice_test extends advanced_testcase {
             $this->assertTrue(zoom_is_meeting_gone_error($error));
             $foundexception = true;
         }
+
         $this->assertTrue($foundexception);
     }
 
@@ -162,6 +163,7 @@ class mod_zoom_webservice_test extends advanced_testcase {
             $this->assertTrue(zoom_is_user_not_found_error($error));
             $foundexception = true;
         }
+
         $this->assertTrue($foundexception || !$founduser);
     }
 
@@ -221,6 +223,7 @@ class mod_zoom_webservice_test extends advanced_testcase {
             $this->assertTrue(zoom_is_user_not_found_error($error));
             $foundexception = true;
         }
+
         $this->assertTrue($foundexception || !$founduser);
     }
 
@@ -257,6 +260,7 @@ class mod_zoom_webservice_test extends advanced_testcase {
                 if ($this->numgetinfocalls <= 3) {
                     return ['http_code' => 429];
                 }
+
                 return ['http_code' => 200];
             }
             // @codingStandardsIgnoreStart
@@ -333,6 +337,7 @@ class mod_zoom_webservice_test extends advanced_testcase {
                 if ($this->numgetinfocalls <= 3) {
                     return ['http_code' => 429];
                 }
+
                 return ['http_code' => 200];
             }
             // @codingStandardsIgnoreStart
@@ -447,6 +452,7 @@ class mod_zoom_webservice_test extends advanced_testcase {
             $foundexception = true;
             $this->assertEquals($error->response, 'too many retries');
         }
+
         $this->assertTrue($foundexception);
         // Check that we retried MAX_RETRIES times.
         $this->assertDebuggingCalledCount(mod_zoom_webservice::MAX_RETRIES);
@@ -456,7 +462,6 @@ class mod_zoom_webservice_test extends advanced_testcase {
      * Tests that we are waiting 1 minute for QPS rate limit types.
      */
     public function test_retryqps_exception() {
-
         $retryqpsmockcurl = new class {
             public $urlpath = null;
             // @codingStandardsIgnoreStart
@@ -496,6 +501,7 @@ class mod_zoom_webservice_test extends advanced_testcase {
                     // We should be getting the same path every time.
                     return '{"code":-1, "message":"incorrect url"}';
                 }
+
                 return '{"code":-1, "message":"too many retries"}';
             }
             // @codingStandardsIgnoreStart
@@ -529,6 +535,7 @@ class mod_zoom_webservice_test extends advanced_testcase {
             $foundexception = true;
             $this->assertEquals($error->response, 'too many retries');
         }
+
         $this->assertTrue($foundexception);
 
         // Check that we waited 1 minute.

--- a/tests/privacy/mod_zoom_provider_test.php
+++ b/tests/privacy/mod_zoom_provider_test.php
@@ -73,8 +73,8 @@ class mod_zoom_provider_test extends \core_privacy\tests\provider_testcase {
         $student = $generator->create_user();
         $student2 = $generator->create_user();
         $studentrole = $DB->get_record('role', ['shortname' => 'student']);
-        $generator->enrol_user($student->id,  $course->id, $studentrole->id);
-        $generator->enrol_user($student2->id,  $course->id, $studentrole->id);
+        $generator->enrol_user($student->id, $course->id, $studentrole->id);
+        $generator->enrol_user($student2->id, $course->id, $studentrole->id);
         // Fill all related data tables.
         $meeting = (object) [
             'id' => 12345,

--- a/view.php
+++ b/view.php
@@ -24,7 +24,7 @@
  * @copyright  2015 UC Regents
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-require_once(__DIR__ . '/../../config.php');
+require(__DIR__ . '/../../config.php');
 require_once(__DIR__ . '/lib.php');
 require_once(__DIR__ . '/locallib.php');
 require_once($CFG->libdir . '/moodlelib.php');

--- a/view.php
+++ b/view.php
@@ -27,9 +27,9 @@
 // Login check require_login() is called in zoom_get_instance_setup();.
 // @codingStandardsIgnoreLine
 require_once(dirname(dirname(dirname(__FILE__))).'/config.php');
-require_once(dirname(__FILE__).'/lib.php');
-require_once(dirname(__FILE__).'/locallib.php');
-require_once(dirname(__FILE__).'/../../lib/moodlelib.php');
+require_once(dirname(__FILE__) . '/lib.php');
+require_once(dirname(__FILE__) . '/locallib.php');
+require_once(dirname(__FILE__) . '/../../lib/moodlelib.php');
 
 $config = get_config('zoom');
 
@@ -185,7 +185,7 @@ if (!$showrecreate && $config->showcapacitywarning == true) {
             $meetingcapacityplaceholders = [
                 'meetingcapacity' => $meetingcapacity,
                 'eligiblemeetingparticipants' => $eligiblemeetingparticipants,
-                'zoomprofileurl' => $config->zoomurl.'/profile',
+                'zoomprofileurl' => $config->zoomurl . '/profile',
                 'courseparticipantsurl' => $participantspageurl->out(),
                 'hostname' => zoom_get_user_display_name($zoom->host_id),
             ];
@@ -348,7 +348,7 @@ if ($zoom->show_schedule) {
 
                 // Create a comma-separated string of the non-Moodle users' mail addresses.
                 foreach ($alternativehostnonusers as &$ah) {
-                    $ah .= ' ('.get_string('externaluser', 'mod_zoom').')';
+                    $ah .= ' (' . get_string('externaluser', 'mod_zoom') . ')';
                 }
 
                 $alternativehostnonusersstring = implode(', ', $alternativehostnonusers);
@@ -356,7 +356,7 @@ if ($zoom->show_schedule) {
                 // Concatenate both strings.
                 // If we have existing Moodle users and non-Moodle users.
                 if ($alternativehostusersstring != '' && $alternativehostnonusersstring != '') {
-                    $alternativehoststring = $alternativehostusersstring.', '.$alternativehostnonusersstring;
+                    $alternativehoststring = $alternativehostusersstring . ', ' . $alternativehostnonusersstring;
 
                     // If we just have existing Moodle users.
                 } else if ($alternativehostusersstring != '') {

--- a/view.php
+++ b/view.php
@@ -24,16 +24,16 @@
  * @copyright  2015 UC Regents
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-// Login check require_login() is called in zoom_get_instance_setup();.
-// @codingStandardsIgnoreLine
-require_once(dirname(dirname(dirname(__FILE__))).'/config.php');
-require_once(dirname(__FILE__) . '/lib.php');
-require_once(dirname(__FILE__) . '/locallib.php');
-require_once(dirname(__FILE__) . '/../../lib/moodlelib.php');
+require_once(__DIR__ . '/../../config.php');
+require_once(__DIR__ . '/lib.php');
+require_once(__DIR__ . '/locallib.php');
+require_once($CFG->libdir . '/moodlelib.php');
+
+require_login();
+// Additional access checks in zoom_get_instance_setup().
+list($course, $cm, $zoom) = zoom_get_instance_setup();
 
 $config = get_config('zoom');
-
-list($course, $cm, $zoom) = zoom_get_instance_setup();
 
 $context = context_module::instance($cm->id);
 $iszoommanager = has_capability('mod/zoom:addinstance', $context);

--- a/view.php
+++ b/view.php
@@ -158,6 +158,7 @@ if ($showrecreate) {
         $message = get_string('zoomerr_meetingnotfound_info', 'mod_zoom');
         $style = \core\output\notification::NOTIFY_WARNING;
     }
+
     echo $OUTPUT->notification($message, $style);
 }
 
@@ -197,6 +198,7 @@ if (!$showrecreate && $config->showcapacitywarning == true) {
                 $meetingcapacitywarning .= get_string('meetingcapacitywarningbodyalthost', 'mod_zoom',
                         $meetingcapacityplaceholders);
             }
+
             $meetingcapacitywarning .= html_writer::empty_tag('br');
             if ($userisrealhost == true) {
                 $meetingcapacitywarning .= get_string('meetingcapacitywarningcontactrealhost', 'mod_zoom');
@@ -236,8 +238,10 @@ if (!$showrecreate) {
             if ($zoom->registration != ZOOM_REGISTRATION_OFF && !$userisregistered) {
                 $btntext = $strregister;
             }
+
             $buttonhtml = html_writer::tag('button', $btntext, ['type' => 'submit', 'class' => 'btn btn-primary']);
         }
+
         $aurl = new moodle_url('/mod/zoom/loadmeeting.php', ['id' => $cm->id]);
         $buttonhtml .= html_writer::input_hidden_params($aurl);
         $link = html_writer::tag('form', $buttonhtml, ['action' => $aurl->out_omit_querystring(), 'target' => '_blank']);
@@ -250,6 +254,7 @@ if (!$showrecreate) {
         // make sense here. So we build the notification manually.
         $link = html_writer::tag('div', $unavailabilitynote, ['class' => 'alert alert-primary']);
     }
+
     echo $OUTPUT->box_start('generalbox text-center');
     echo $link;
     echo $OUTPUT->box_end();
@@ -277,6 +282,7 @@ if ($zoom->show_schedule) {
         } else {
             $table->data[] = [get_string('nextoccurrence', 'mod_zoom'), get_string('nooccurrenceleft', 'mod_zoom')];
         }
+
         $table->data[] = [$strduration, format_time($zoom->duration)];
     } else {
         $table->data[] = [$strtime, userdate($zoom->start_time)];
@@ -315,6 +321,7 @@ if ($zoom->show_schedule) {
         } else {
             $status = get_string('meeting_not_started', 'mod_zoom');
         }
+
         $table->data[] = [$strstatus, $status];
     }
 
@@ -343,6 +350,7 @@ if ($zoom->show_schedule) {
                 foreach ($alternativehostnonusers as &$ah) {
                     $ah .= ' ('.get_string('externaluser', 'mod_zoom').')';
                 }
+
                 $alternativehostnonusersstring = implode(', ', $alternativehostnonusers);
 
                 // Concatenate both strings.


### PR DESCRIPTION
When a rule does not exist in [Moodle's Coding Style](https://moodledev.io/general/development/policies/codingstyle) document, it defers to [PSR-12](https://www.php-fig.org/psr/psr-12/), and [PSR-1](https://www.php-fig.org/psr/psr-1/) in that order.

So I checked to see what would happen if I added the PSR1 and PSR12 rulesets to the core Moodle ruleset and then excluded the entries that seemed to conflict with existing Moodle styles. Here's the result:
```xml
    <rule ref="PSR1">
        <exclude name="PSR1.Classes.ClassDeclaration"/>
        <exclude name="PSR1.Files.SideEffects"/>
        <exclude name="PSR1.Methods.CamelCapsMethodName"/>
    </rule>
    <rule ref="PSR12">
        <exclude name="Generic.Files.LineLength"/>
        <exclude name="PSR12.ControlStructures.ControlStructureSpacing"/>
        <exclude name="PSR12.Files.FileHeader"/>
        <exclude name="PSR2.Classes.ClassDeclaration"/>
        <exclude name="PSR2.ControlStructures.ElseIfDeclaration"/>
        <exclude name="PSR2.Methods.FunctionCallSignature"/>
        <exclude name="Squiz.Classes.ValidClassName"/>
        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration"/>
    </rule>
```

With that in place, the remaining items were Moodle-compatible changes and included some nice cleanups for readability, class constant visibility, file inclusion, and highlighted a unit test that has been programmatically skipped for years.