### PR TITLE
Set default for option_auto_record for older restores

### DIFF
--- a/backup/moodle2/restore_zoom_stepslib.php
+++ b/backup/moodle2/restore_zoom_stepslib.php
@@ -70,6 +70,7 @@ class restore_zoom_activity_structure_step extends restore_activity_structure_st
             $data->join_url = '';
             $data->meeting_id = 0;
             $data->exists_on_zoom = ZOOM_MEETING_EXPIRED;
+            $data->option_auto_recording = 'none';
         }
 
         $data->course = $this->get_courseid();

--- a/lib.php
+++ b/lib.php
@@ -331,6 +331,9 @@ function populate_zoom_from_response(stdClass $zoom, stdClass $response) {
     if (isset($response->settings->auto_recording)) {
         $newzoom->option_auto_recording = $response->settings->auto_recording;
     }
+    if (!isset($newzoom->option_auto_recording)) {
+        $newzoom->option_auto_recording = 'none';
+    }
 
     return $newzoom;
 }


### PR DESCRIPTION
When restoring a course containing a zoom activity that existed prior to the auto_recording changes ( #390 ), the option_auto_recording property is not set and runs into a database NULL not allowed error.

The fix in restore_zoom_stepslib.php resolves the issue but I thought it may be safe to add the check within populate_zoom_from_response as well.  This second addition may not be needed.

Fixes #455 