### PR TITLE
oauth: Check required scopes; use POST data

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ To connect to the Zoom APIs, this plugin requires an account-level app to be
 created.
 
 ### Server-to-Server OAuth
-To [create an account-level Server-to-Server OAuth app](https://marketplace.zoom.us/docs/guides/build/server-to-server-oauth-app), the `Server-to-server OAuth app`
-permission is required.
+To [create an account-level Server-to-Server OAuth app](https://developers.zoom.us/docs/internal-apps/create/), the `Server-to-server OAuth app`
+permission is required. You should create a separate Server-to-Server OAuth app for each Moodle install.
 
 The Server-to-Server OAuth app will generate a client ID, client secret and account ID.
 
@@ -23,7 +23,7 @@ At a minimum, the following scopes are required by this plugin:
 - meeting:write:admin (Create/Update meetings)
 - user:read:admin (Read user details)
 
-Additional scopes are required for certain functionality:
+Optional functionality can be enabled by granting additional scopes:
 
 - Reports for meetings / webinars
     - dashboard_meetings:read:admin (Business accounts and higher)
@@ -43,13 +43,12 @@ Additional scopes are required for certain functionality:
 JWT will be deprecated in June 2023. To create an account-level JWT app the 'JWT' permission is
 required.
 
-See https://marketplace.zoom.us/docs/guides/build/jwt-app. You will need to
-create a JWT app and that will generate the API key and secret.
+You will need to [create a JWT app](https://developers.zoom.us/docs/platform/build/jwt-app/) and that will generate the API key and secret.
 
 ## Installation
 
-1. Install plugin to mod/zoom. More details at https://docs.moodle.org/en/Installing_plugins#Installing_a_plugin
-2. Once you install the plugin you need to set the following settings to enable the plugin:
+1. [Install plugin](https://docs.moodle.org/en/Installing_plugins#Installing_a_plugin) to the /mod/zoom folder in Moodle.
+2. After installing the plugin, the following settings need to be configured to use the plugin:
 
 - Zoom account ID (mod_zoom | accountid)
 - Zoom client ID (mod_zoom | clientid)
@@ -60,12 +59,10 @@ JWT will be deprecated in June 2023. For a JWT app, you need to set the followin
 - Zoom API key (mod_zoom | apikey)
 - Zoom API secret (mod_zoom | apisecret)
 
-Please note that the API key and secret is not the same as the LTI key/secret.
+Please note that the API key and secret are not the same as the LTI key/secret.
 
 If you get "Access token is expired" errors, make sure the date/time on your
 server is properly synchronized with the time servers.
-
-- Zoom home page URL (mod_zoom | zoomurl), Link to your organization's custom Zoom landing page.
 
 ## Changelog
 
@@ -113,7 +110,7 @@ v4.8.0
 
 - Feature: Support Server-to-Server OAuth app #387 (thanks @haietza, @mhughes2k)
   - New settings `zoom/accountid`, `zoom/clientid`, `zoom/clientsecret`
-  - Reminder: You must [switch from JWT to Server-to-Server OAuth by June 2023](https://marketplace.zoom.us/docs/guides/build/jwt-app/jwt-faq/).
+  - Reminder: You must [switch from JWT to Server-to-Server OAuth by June 2023](https://developers.zoom.us/docs/internal-apps/jwt-faq/).
 - Regression: Locked settings were not being applied #407 (thanks @krab-stik)
   - Introduced in v4.7.0 while adding support for automatic recording.
 

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -1072,7 +1072,7 @@ class mod_zoom_webservice {
             'meeting:write:admin',
             'user:read:admin',
         ];
-        $scopes = explode(' ', $response->scopes);
+        $scopes = explode(' ', $response->scope);
         $missingscopes = array_diff($requiredscopes, $scopes);
 
         if (!empty($missingscopes)) {

--- a/lang/en/zoom.php
+++ b/lang/en/zoom.php
@@ -402,6 +402,7 @@ $string['zoomerr_maxretries'] = 'Retried {$a->maxretries} times to make the call
 $string['zoomerr_meetingnotfound'] = 'This meeting cannot be found on Zoom. You can <a href="{$a->recreate}">recreate it here</a> or <a href="{$a->delete}">delete it completely</a>.';
 $string['zoomerr_meetingnotfound_info'] = 'This meeting cannot be found on Zoom. Please contact the meeting host if you have questions.';
 $string['zoomerr_no_access_token'] = 'No access token returned';
+$string['zoomerr_scopes'] = 'The Zoom OAuth configuration is missing these required scopes: {$a}';
 $string['zoomerr_usernotfound'] = 'Unable to find your account on Zoom. If you are using Zoom for the first time, you must activate your Zoom account by logging into <a href="{$a}" target="_blank">{$a}</a>. Once you\'ve activated your Zoom account, reload this page and continue setting up your meeting. Else make sure your email on Zoom matches your email on this system.';
 $string['zoomerr_alternativehostusernotfound'] = 'User {$a} was not found on Zoom.';
 $string['zoomerr_viewrecordings_off'] = 'View Recordings is switched off, task cannot run';


### PR DESCRIPTION
This should avoid caching tokens that do not have the required scopes. Also, update documentation to make it clear that "You should create a separate Server-to-Server OAuth app for each Moodle install."

Fixes #473 
Fixes #474