### PR TITLE
fix default activity completion editing issue

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -48,7 +48,6 @@ class mod_zoom_mod_form extends moodleform_mod {
     public function definition() {
         global $PAGE, $USER, $OUTPUT;
         $config = get_config('zoom');
-        $PAGE->requires->css(new moodle_url('/mod/zoom/styles.css'));
         $PAGE->requires->js_call_amd("mod_zoom/form", 'init');
 
         $isnew = empty($this->_cm);


### PR DESCRIPTION
Related to issue #478

The error is a result of line 51 in mod_form.php. The system will automatically include the styles.css file in the plugin, deleting line 51 will keep the CSS styles but resolve the error.
