### PR TITLE
completion: avoid unnecessary form overhead on completion forms

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -47,6 +47,12 @@ class mod_zoom_mod_form extends moodleform_mod {
      */
     public function definition() {
         global $PAGE, $USER, $OUTPUT;
+
+        // We don't do anything custom with completion data, so avoid doing any unnecessary work.
+        if ($PAGE->pagetype === 'course-editbulkcompletion' || $PAGE->pagetype === 'course-editdefaultcompletion') {
+            return;
+        }
+
         $config = get_config('zoom');
         $PAGE->requires->js_call_amd("mod_zoom/form", 'init');
 


### PR DESCRIPTION
Noticed this while testing #479. It seems that the Activity Completion "defaults" and "bulk editing" forms want to give modules the opportunity to modify items in the form. At this time, the Zoom module does not modify any of the Activity Completion fields as part of the mod_form definition(). So it seems like we can exit immediately from the definition() function if we can identify that we are in one of those two contexts. The benefit is that we can avoid making several unnecessary API calls that either noticeably delay the page load time or that trigger exceptions which prevent the Activity Completion data from being modified.

This proposed fix feels like I'm cheating the process, but as far as I can find, it's the best way to address the problem. I opened a thread in the Moodle developer forum asking about it, but I have not yet received a response.