### PR TITLE
errors: add exception parent for cleaner error handling

### DIFF
--- a/classes/webservice_exception.php
+++ b/classes/webservice_exception.php
@@ -1,0 +1,60 @@
+<?php
+// This file is part of the Zoom plugin for Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Exception class for Zoom API errors.
+ *
+ * @package   mod_zoom
+ * @copyright 2023 Jonathan Champ <jrchamp@ncsu.edu>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_zoom;
+
+/**
+ * Webservice exception class.
+ */
+class webservice_exception extends \moodle_exception {
+    /**
+     * Web service response.
+     * @var string
+     */
+    public $response = null;
+
+    /**
+     * Web service error code.
+     * @var int
+     */
+    public $zoomerrorcode = null;
+
+    /**
+     * Constructor
+     *
+     * @param string $response Webservice response body.
+     * @param int $zoomerrorcode Webservice response error code.
+     * @param string $errorcode The name of the string from error.php to print
+     * @param string $module name of module
+     * @param string $link The url where the user will be directed. Else, the user will be directed to the site index page.
+     * @param mixed $a Extra words and phrases that might be required in the error string
+     * @param string $debuginfo optional debugging information
+     */
+    public function __construct($response, $zoomerrorcode, $errorcode, $module = '', $link = '', $a = null, $debuginfo = null) {
+        $this->response = $response;
+        $this->zoomerrorcode = $zoomerrorcode;
+
+        parent::__construct($errorcode, $module, $link, $a, $debuginfo);
+    }
+}

--- a/lib.php
+++ b/lib.php
@@ -378,9 +378,6 @@ function zoom_delete_instance($id) {
         } catch (zoom_not_found_exception $error) {
             // Meeting not on Zoom, so continue.
             mtrace('Meeting not on Zoom; continuing');
-        } catch (moodle_exception $error) {
-            // Some other error, so throw error.
-            throw $error;
         }
     }
 

--- a/locallib.php
+++ b/locallib.php
@@ -29,6 +29,7 @@ defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 require_once($CFG->dirroot . '/mod/zoom/lib.php');
+require_once($CFG->dirroot . '/mod/zoom/classes/webservice_exception.php');
 require_once($CFG->dirroot . '/mod/zoom/classes/webservice.php');
 
 // Constants.
@@ -114,82 +115,52 @@ define('ZOOM_REGISTRATION_OFF', 2);
 /**
  * Entry not found on Zoom.
  */
-class zoom_not_found_exception extends moodle_exception {
-    /**
-     * Web service response.
-     * @var string
-     */
-    public $response = null;
-
+class zoom_not_found_exception extends \mod_zoom\webservice_exception {
     /**
      * Constructor
      * @param string $response      Web service response message
      * @param int $errorcode     Web service response error code
      */
     public function __construct($response, $errorcode) {
-        $this->response = $response;
-        $this->zoomerrorcode = $errorcode;
-        parent::__construct('errorwebservice_notfound', 'zoom');
+        parent::__construct($response, $errorcode, 'errorwebservice_notfound', 'mod_zoom');
     }
 }
 
 /**
  * Bad request received by Zoom.
  */
-class zoom_bad_request_exception extends moodle_exception {
-    /**
-     * Web service response.
-     * @var string
-     */
-    public $response = null;
-
+class zoom_bad_request_exception extends \mod_zoom\webservice_exception {
     /**
      * Constructor
      * @param string $response      Web service response message
      * @param int $errorcode     Web service response error code
      */
     public function __construct($response, $errorcode) {
-        $this->response = $response;
-        $this->zoomerrorcode = $errorcode;
-        parent::__construct('errorwebservice_badrequest', 'zoom', '', $response);
+        parent::__construct($response, $errorcode, 'errorwebservice_badrequest', 'mod_zoom', '', $response);
     }
 }
 
 /**
  * Couldn't succeed within the allowed number of retries.
  */
-class zoom_api_retry_failed_exception extends moodle_exception {
-    /**
-     * Web service response.
-     * @var string
-     */
-    public $response = null;
-
+class zoom_api_retry_failed_exception extends \mod_zoom\webservice_exception {
     /**
      * Constructor
      * @param string $response      Web service response
      * @param int $errorcode     Web service response error code
      */
     public function __construct($response, $errorcode) {
-        $this->response = $response;
-        $this->zoomerrorcode = $errorcode;
         $a = new stdClass();
         $a->response = $response;
         $a->maxretries = mod_zoom_webservice::MAX_RETRIES;
-        parent::__construct('zoomerr_maxretries', 'zoom', '', $a);
+        parent::__construct($response, $errorcode, 'zoomerr_maxretries', 'mod_zoom', '', $a);
     }
 }
 
 /**
  * Exceeded daily API limit.
  */
-class zoom_api_limit_exception extends moodle_exception {
-    /**
-     * Web service response.
-     * @var string
-     */
-    public $response = null;
-
+class zoom_api_limit_exception extends \mod_zoom\webservice_exception {
     /**
      * Unix timestamp of next time to API can be called.
      * @var int
@@ -203,12 +174,11 @@ class zoom_api_limit_exception extends moodle_exception {
      * @param int $retryafter   Unix timestamp of next time to API can be called.
      */
     public function __construct($response, $errorcode, $retryafter) {
-        $this->response = $response;
-        $this->zoomerrorcode = $errorcode;
         $this->retryafter = $retryafter;
+
         $a = new stdClass();
         $a->response = $response;
-        parent::__construct('zoomerr_apilimit', 'zoom', '',
+        parent::__construct($response, $errorcode, 'zoomerr_apilimit', 'mod_zoom', '',
                 userdate($retryafter, get_string('strftimedaydatetime', 'core_langconfig')));
     }
 }

--- a/mod_form.php
+++ b/mod_form.php
@@ -119,7 +119,7 @@ class mod_zoom_mod_form extends moodleform_mod {
         if (!$isnew) {
             try {
                 zoom_webservice()->get_meeting_webinar_info($this->current->meeting_id, $this->current->webinar);
-            } catch (moodle_exception $error) {
+            } catch (\mod_zoom\webservice_exception $error) {
                 // If the meeting can't be found, offer to recreate the meeting on Zoom.
                 if (zoom_is_meeting_gone_error($error)) {
                     $errstring = 'zoomerr_meetingnotfound';

--- a/tests/mod_zoom_webservice_test.php
+++ b/tests/mod_zoom_webservice_test.php
@@ -26,7 +26,7 @@ namespace mod_zoom;
 
 use advanced_testcase;
 use mod_zoom_webservice;
-use moodle_exception;
+use mod_zoom\webservice_exception;
 use zoom_api_retry_failed_exception;
 
 /**
@@ -124,7 +124,7 @@ class mod_zoom_webservice_test extends advanced_testcase {
         $foundexception = false;
         try {
             $response = $mockservice->get_meeting_webinar_info('-1', false);
-        } catch (moodle_exception $error) {
+        } catch (webservice_exception $error) {
             $this->assertEquals(3001, $error->zoomerrorcode);
             $this->assertTrue(zoom_is_meeting_gone_error($error));
             $foundexception = true;
@@ -156,7 +156,7 @@ class mod_zoom_webservice_test extends advanced_testcase {
         $foundexception = false;
         try {
             $founduser = $mockservice->get_user('-1');
-        } catch (moodle_exception $error) {
+        } catch (webservice_exception $error) {
             $this->assertEquals(1001, $error->zoomerrorcode);
             $this->assertTrue(zoom_is_meeting_gone_error($error));
             $this->assertTrue(zoom_is_user_not_found_error($error));
@@ -216,7 +216,7 @@ class mod_zoom_webservice_test extends advanced_testcase {
         $foundexception = false;
         try {
             $founduser = $mockservice->get_user('-1');
-        } catch (moodle_exception $error) {
+        } catch (webservice_exception $error) {
             $this->assertEquals(1120, $error->zoomerrorcode);
             $this->assertTrue(zoom_is_meeting_gone_error($error));
             $this->assertTrue(zoom_is_user_not_found_error($error));
@@ -530,7 +530,7 @@ class mod_zoom_webservice_test extends advanced_testcase {
         $foundexception = false;
         try {
             $result = $mockservice->get_meetings('2020-01-01', '2020-01-02');
-        } catch (moodle_exception $error) {
+        } catch (webservice_exception $error) {
             $foundexception = true;
             $this->assertEquals($error->response, 'too many retries');
         }

--- a/view.php
+++ b/view.php
@@ -72,7 +72,7 @@ if ($zoom->exists_on_zoom == ZOOM_MEETING_EXPIRED) {
 } else {
     try {
         zoom_webservice()->get_meeting_webinar_info($zoom->meeting_id, $zoom->webinar);
-    } catch (moodle_exception $error) {
+    } catch (\mod_zoom\webservice_exception $error) {
         $showrecreate = zoom_is_meeting_gone_error($error);
 
         if ($showrecreate) {
@@ -84,6 +84,9 @@ if ($zoom->exists_on_zoom == ZOOM_MEETING_EXPIRED) {
 
             $zoom->exists_on_zoom = ZOOM_MEETING_EXPIRED;
         }
+    } catch (moodle_exception $error) {
+        // Ignore other exceptions.
+        debugging($error->getMessage());
     }
 }
 


### PR DESCRIPTION
The problem was that we were catching `moodle_exception` and assuming that it had the Zoom-specific webservice exception member variables. By creating a layer in between the specialized Zoom exceptions and the generic `moodle_exception`, we can guarantee that the functions will have exceptions which include the expected member variables. This also de-duplicates some of the exception code that was repeated in each of the specialized exceptions.

This also has the benefit of fixing a PHP 8.2 issue related to dynamic member variables on classes (because most of the specialized classes did not pre-define the zoomerrrorcode variable).

Fixes #468