### PR TITLE
Release/v4.10.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,17 @@ jobs:
           coverage: none
 
       - name: Initialise moodle-plugin-ci
+        if: ${{ matrix.php >= '7.4' }}
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^4
+
+      - name: Initialise moodle-plugin-ci v3
+        if: ${{ matrix.php < '7.4' }}
         run: |
           composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
+
+      - name: Set up environment
+        run: |
           echo $(cd ci/bin; pwd) >> $GITHUB_PATH
           echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
           sudo locale-gen en_AU.UTF-8

--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ server is properly synchronized with the time servers.
 
 ## Changelog
 
+v4.10.2
+
+- Regression: Instructors were unable to edit Zoom activity completion defaults #479 (thanks @phette23)
+  - Introduced in v4.6.0 when adding breakout room support.
+- Bugfix: Course reset now verifies that the Zoom checkbox is checked #483 (thanks @carlosalal)
+
 v4.10.1
 
 - Bugfix: Stop showing finished events in My Overview block #451 (thanks @nstefanski)

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_zoom';
-$plugin->version = 2023042800;
-$plugin->release = 'v4.10.1';
+$plugin->version = 2023051900;
+$plugin->release = 'v4.10.2';
 $plugin->requires = 2017111300;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->cron = 0;


### PR DESCRIPTION
A couple nice fixes that will help people using these features (course reset, editing default/bulk activity completion). I also made it so that versions of PHP >= 7.4 use moodle-plugin-ci v4.