### PR TITLE
release: v4.10.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ server is properly synchronized with the time servers.
 
 ## Changelog
 
+v4.10.3
+- Bugfix: Also use proxy settings for OAuth token request #494 (thanks @adnbes)
+- Bugfix: Clean up exception handling to avoid notice #482 (thanks @andremenrath)
+- Bugfix: Avoid course/activity completion form overhead #481 (thanks @phette23)
+- Regression: PHP 7.0 class constant visibility errors #495 (thanks @rlaneIT)
+  - Introduced in v4.10.1 when aligning with PSR-12 coding standards.
+
 v4.10.2
 
 - Regression: Instructors were unable to edit Zoom activity completion defaults #479 (thanks @phette23)

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_zoom';
-$plugin->version = 2023051900;
-$plugin->release = 'v4.10.2';
+$plugin->version = 2023063000;
+$plugin->release = 'v4.10.3';
 $plugin->requires = 2017111300;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->cron = 0;


### PR DESCRIPTION
This bugfix release may be the last update to the `v4` branch. `main` will continue moving forward as the `v5` branch. Make sure to copy the release notes forward to the v5.0.0 release.