### PR TITLE
release: v5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ server is properly synchronized with the time servers.
 
 ## Changelog
 
+v5.0.0
+- Backward incompatible: Drop support for JWT authentication (thanks @aspark21)
+  - Zoom requires everyone to use Server-to-Server OAuth by September 1, 2023
+- Backward incompatible: Require PHP 7.1+ (Moodle 3.7+) (thanks @rlaneIT)
+- Backward incompatible: Drop Moodle 3.4 mobile support
+
+v4.10.3
+- Bugfix: Also use proxy settings for OAuth token request #494 (thanks @adnbes)
+- Bugfix: Clean up exception handling to avoid notice #482 (thanks @andremenrath)
+- Bugfix: Avoid course/activity completion form overhead #481 (thanks @phette23)
+- Regression: PHP 7.0 class constant visibility errors #495 (thanks @rlaneIT)
+  - Introduced in v4.10.1 when aligning with PSR-12 coding standards.
+
 v4.10.2
 
 - Regression: Instructors were unable to edit Zoom activity completion defaults #479 (thanks @phette23)

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_zoom';
-$plugin->version = 2023051900;
-$plugin->release = 'v4.10.2';
-$plugin->requires = 2017111300;
+$plugin->version = 2023070300;
+$plugin->release = 'v5.0.0';
+$plugin->requires = 2019052000;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->cron = 0;


### PR DESCRIPTION
This release sheds the deprecated JWT library, the forgotten Moodle mobile zip file and properly reflects the PHP 7.1+ requirement that was accidentally introduced in v4.10.1.