### PR TITLE
Database upgrade.php and schema consistency

### DIFF
--- a/backup/moodle2/restore_zoom_stepslib.php
+++ b/backup/moodle2/restore_zoom_stepslib.php
@@ -68,7 +68,6 @@ class restore_zoom_activity_structure_step extends restore_activity_structure_st
             $data->join_url = '';
             $data->meeting_id = 0;
             $data->exists_on_zoom = ZOOM_MEETING_EXPIRED;
-            $data->option_auto_recording = 'none';
         }
 
         $data->course = $this->get_courseid();

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="mod/zoom/db" VERSION="20221003" COMMENT="Zoom module"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
+<XMLDB PATH="mod/zoom/db" VERSION="20230803" COMMENT="Zoom module"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
   <TABLES>
     <TABLE NAME="zoom" COMMENT="Zoom meetings and webinars">
@@ -20,16 +20,16 @@
         <FIELD NAME="start_time" TYPE="int" LENGTH="12" NOTNULL="false" SEQUENCE="false" COMMENT="Meeting start time (Unix timestamp, seconds). For scheduled meeting only."/>
         <FIELD NAME="timemodified" TYPE="int" LENGTH="12" NOTNULL="false" SEQUENCE="false" COMMENT="Timestamp when the instance was last modified."/>
         <FIELD NAME="recurring" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="Is the meeting or webinar recurring?"/>
-        <FIELD NAME="recurrence_type" TYPE="int" LENGTH="1" NOTNULL="false" SEQUENCE="false" COMMENT="Is the recurring meeting weekly, daily or monthly" />
-        <FIELD NAME="repeat_interval" TYPE="int" LENGTH="2" NOTNULL="false" SEQUENCE="false" COMMENT="Specify the repeat interval of the meeting" />
-        <FIELD NAME="weekly_days" TYPE="char" LENGTH="14" NOTNULL="false" SEQUENCE="false" COMMENT="Specify the days for weekly recurring meetings" />
-        <FIELD NAME="monthly_day" TYPE="int" LENGTH="2" NOTNULL="false" SEQUENCE="false" COMMENT="Specify the day for a recurring monthly meeting" />
-        <FIELD NAME="monthly_week" TYPE="int" LENGTH="2" NOTNULL="false" SEQUENCE="false" COMMENT="Specify the week for a recurring monthly meeting" />
-        <FIELD NAME="monthly_week_day" TYPE="int" LENGTH="1" NOTNULL="false" SEQUENCE="false" COMMENT="Specify a day of the week for a recurring monthly meeting" />
-        <FIELD NAME="monthly_repeat_option" TYPE="int" LENGTH="1" NOTNULL="false" SEQUENCE="false" COMMENT="For UI purposes. To determine which monthly repeat option is chosen" />
-        <FIELD NAME="end_times" TYPE="int" LENGTH="2" NOTNULL="false" SEQUENCE="false" COMMENT="The amount of times meeting should occur before its canceled" />
-        <FIELD NAME="end_date_time" TYPE="int" LENGTH="12" NOTNULL="false" SEQUENCE="false" COMMENT="The final date (Unix timestamp, seconds) of the meeting before its canceled" />
-        <FIELD NAME="end_date_option" TYPE="int" LENGTH="1" NOTNULL="false" SEQUENCE="false" COMMENT="For UI purposes. To determine which end date option is chosen" />
+        <FIELD NAME="recurrence_type" TYPE="int" LENGTH="1" NOTNULL="false" SEQUENCE="false" COMMENT="Is the recurring meeting weekly, daily or monthly"/>
+        <FIELD NAME="repeat_interval" TYPE="int" LENGTH="2" NOTNULL="false" SEQUENCE="false" COMMENT="Specify the repeat interval of the meeting"/>
+        <FIELD NAME="weekly_days" TYPE="char" LENGTH="14" NOTNULL="false" SEQUENCE="false" COMMENT="Specify the days for weekly recurring meetings"/>
+        <FIELD NAME="monthly_day" TYPE="int" LENGTH="2" NOTNULL="false" SEQUENCE="false" COMMENT="Specify the day for a recurring monthly meeting"/>
+        <FIELD NAME="monthly_week" TYPE="int" LENGTH="2" NOTNULL="false" SEQUENCE="false" COMMENT="Specify the week for a recurring monthly meeting"/>
+        <FIELD NAME="monthly_week_day" TYPE="int" LENGTH="1" NOTNULL="false" SEQUENCE="false" COMMENT="Specify a day of the week for a recurring monthly meeting"/>
+        <FIELD NAME="monthly_repeat_option" TYPE="int" LENGTH="1" NOTNULL="false" SEQUENCE="false" COMMENT="For UI purposes. To determine which monthly repeat option is chosen"/>
+        <FIELD NAME="end_times" TYPE="int" LENGTH="2" NOTNULL="false" SEQUENCE="false" COMMENT="The amount of times meeting should occur before its canceled"/>
+        <FIELD NAME="end_date_time" TYPE="int" LENGTH="12" NOTNULL="false" SEQUENCE="false" COMMENT="The final date (Unix timestamp, seconds) of the meeting before its canceled"/>
+        <FIELD NAME="end_date_option" TYPE="int" LENGTH="1" NOTNULL="false" SEQUENCE="false" COMMENT="For UI purposes. To determine which end date option is chosen"/>
         <FIELD NAME="webinar" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="Is this a webinar?"/>
         <FIELD NAME="duration" TYPE="int" LENGTH="6" NOTNULL="false" SEQUENCE="false" COMMENT="Meeting duration (seconds). For scheduled meeting only."/>
         <FIELD NAME="timezone" TYPE="char" LENGTH="50" NOTNULL="false" SEQUENCE="false" COMMENT="Timezone to format start_time, like &quot;America/Los_Angeles&quot;. For scheduled meeting only."/>
@@ -45,12 +45,12 @@
         <FIELD NAME="option_encryption_type" TYPE="char" LENGTH="20" NOTNULL="false" DEFAULT="enhanced_encryption" SEQUENCE="false" COMMENT="Meeting encryption type. Can be &quot;enhanced_encryption&quot;, &quot;e2ee&quot;"/>
         <FIELD NAME="exists_on_zoom" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Whether the meeting can be found on Zoom servers. Usually should be true, should only be false if API call returned that meeting can't be found."/>
         <FIELD NAME="alternative_hosts" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="recordings_visible_default" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Should the recordings for this meeting be visible by default" />
-        <FIELD NAME="show_schedule" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Show Schedule heading in activity page" />
-        <FIELD NAME="show_security" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Show Security heading in activity page" />
-        <FIELD NAME="show_media" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Show Media heading in activity page" />
-        <FIELD NAME="option_auto_recording" TYPE="char" LENGTH="5" NOTNULL="false" SEQUENCE="false" COMMENT="Auto record meeting." />
-        <FIELD NAME="registration" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="2" SEQUENCE="false" COMMENT="Force participants to register for the meeting/webinar" />
+        <FIELD NAME="recordings_visible_default" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Should the recordings for this meeting be visible by default"/>
+        <FIELD NAME="show_schedule" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Show Schedule heading in activity page"/>
+        <FIELD NAME="show_security" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Show Security heading in activity page"/>
+        <FIELD NAME="show_media" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Show Media heading in activity page"/>
+        <FIELD NAME="option_auto_recording" TYPE="char" LENGTH="5" NOTNULL="false" SEQUENCE="false" COMMENT="Auto record meeting."/>
+        <FIELD NAME="registration" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="2" SEQUENCE="false" COMMENT="Force participants to register for the meeting/webinar"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
@@ -125,8 +125,8 @@
         <FIELD NAME="externalurl" TYPE="text" NOTNULL="true" SEQUENCE="false" COMMENT="Link to view the recording."/>
         <FIELD NAME="passcode" TYPE="char" LENGTH="30" NOTNULL="false" SEQUENCE="false" COMMENT="Passcode to access the recording."/>
         <FIELD NAME="recordingtype" TYPE="char" LENGTH="30" NOTNULL="true" SEQUENCE="false" COMMENT="Type of recording."/>
-        <FIELD NAME="recordingstart" TYPE="int" LENGTH="12" NOTNULL="true" SEQUENCE="false" />
-        <FIELD NAME="showrecording" TYPE="int" LENGTH="1" NOTNULL="true" SEQUENCE="false" DEFAULT="0" />
+        <FIELD NAME="recordingstart" TYPE="int" LENGTH="12" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="showrecording" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="timecreated" TYPE="int" LENGTH="12" NOTNULL="false" SEQUENCE="false" COMMENT="Timestamp when the record was created."/>
         <FIELD NAME="timemodified" TYPE="int" LENGTH="12" NOTNULL="false" SEQUENCE="false" COMMENT="Timestamp when the record was last modified."/>
       </FIELDS>

--- a/db/install.xml
+++ b/db/install.xml
@@ -49,7 +49,7 @@
         <FIELD NAME="show_schedule" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Show Schedule heading in activity page" />
         <FIELD NAME="show_security" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Show Security heading in activity page" />
         <FIELD NAME="show_media" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Show Media heading in activity page" />
-        <FIELD NAME="option_auto_recording" TYPE="char" LENGTH="5" NOTNULL="true" DEFAULT="none" SEQUENCE="false" COMMENT="Auto record meeting." />
+        <FIELD NAME="option_auto_recording" TYPE="char" LENGTH="5" NOTNULL="false" SEQUENCE="false" COMMENT="Auto record meeting." />
         <FIELD NAME="registration" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="2" SEQUENCE="false" COMMENT="Force participants to register for the meeting/webinar" />
       </FIELDS>
       <KEYS>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -818,7 +818,7 @@ function xmldb_zoom_upgrade($oldversion) {
         $table = new xmldb_table('zoom');
 
         // Define and conditionally add field option_auto_recording.
-        $field = new xmldb_field('option_auto_recording', XMLDB_TYPE_CHAR, '5', null, XMLDB_NOTNULL, null, 'none', 'show_media');
+        $field = new xmldb_field('option_auto_recording', XMLDB_TYPE_CHAR, '5', null, null, null, null, 'show_media');
         if (!$dbman->field_exists($table, $field)) {
             $dbman->add_field($table, $field);
         }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -735,19 +735,19 @@ function xmldb_zoom_upgrade($oldversion) {
         $table = new xmldb_table('zoom');
 
         // Define and conditionally add field show_schedule.
-        $field = new xmldb_field('show_schedule', XMLDB_TYPE_INTEGER, '1', null, null, null, '1', 'recordings_visible_default');
+        $field = new xmldb_field('show_schedule', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '1', 'recordings_visible_default');
         if (!$dbman->field_exists($table, $field)) {
             $dbman->add_field($table, $field);
         }
 
         // Define and conditionally add field show_security.
-        $field = new xmldb_field('show_security', XMLDB_TYPE_INTEGER, '1', null, null, null, '1', 'show_schedule');
+        $field = new xmldb_field('show_security', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '1', 'show_schedule');
         if (!$dbman->field_exists($table, $field)) {
             $dbman->add_field($table, $field);
         }
 
         // Define and conditionally add field show_media.
-        $field = new xmldb_field('show_media', XMLDB_TYPE_INTEGER, '1', null, null, null, '1', 'show_security');
+        $field = new xmldb_field('show_media', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '1', 'show_security');
         if (!$dbman->field_exists($table, $field)) {
             $dbman->add_field($table, $field);
         }
@@ -817,7 +817,7 @@ function xmldb_zoom_upgrade($oldversion) {
         $table = new xmldb_table('zoom');
 
         // Define and conditionally add field option_auto_recording.
-        $field = new xmldb_field('option_auto_recording', XMLDB_TYPE_CHAR, '5', null, null, null, null, 'show_media');
+        $field = new xmldb_field('option_auto_recording', XMLDB_TYPE_CHAR, '5', null, XMLDB_NOTNULL, null, 'none', 'show_media');
         if (!$dbman->field_exists($table, $field)) {
             $dbman->add_field($table, $field);
         }
@@ -837,6 +837,29 @@ function xmldb_zoom_upgrade($oldversion) {
 
         // Zoom savepoint reached.
         upgrade_mod_savepoint(true, 2022102700, 'zoom');
+    }
+
+    if ($oldversion < 2023080202) {
+        // Issue #432: Inconsistency between the DB and schema, this is to verify everything matches.
+        // Verify show_schedule, show_security, and show_media are all set to NOTNULL.
+        // Verify option_auto_record is set to NOTNULL and defaults to "none"
+        $table = new xmldb_table('zoom');
+
+        // Launch change of nullability for show schedule
+        $field = new xmldb_field('show_schedule', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '1', 'recordings_visible_default');
+        $dbman->change_field_notnull($table, $field);
+
+        $field = new xmldb_field('show_security', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '1', 'show_schedule');
+        $dbman->change_field_notnull($table, $field);
+
+        $field = new xmldb_field('show_media', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '1', 'show_security');
+        $dbman->change_field_notnull($table, $field);
+
+        $field = new xmldb_field('option_auto_recording', XMLDB_TYPE_CHAR, '5', null, XMLDB_NOTNULL, null, 'none', 'show_media');
+        $dbman->change_field_type($table, $field);
+
+        // Zoom savepoint reached.
+        upgrade_mod_savepoint(true, 2023080202, 'zoom');
     }
 
     return true;

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -847,7 +847,8 @@ function xmldb_zoom_upgrade($oldversion) {
         $table = new xmldb_table('zoom');
 
         // Launch change of nullability for show schedule.
-        $field = new xmldb_field('show_schedule', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '1', 'recordings_visible_default');
+        $field = new xmldb_field('show_schedule', XMLDB_TYPE_INTEGER, '1',
+            null, XMLDB_NOTNULL, null, '1', 'recordings_visible_default');
         $dbman->change_field_notnull($table, $field);
 
         $field = new xmldb_field('show_security', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '1', 'show_schedule');

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -830,7 +830,7 @@ function xmldb_zoom_upgrade($oldversion) {
         $table = new xmldb_table('zoom');
 
         // Define and conditionally add field registration.
-        $field = new xmldb_field('registration', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '2', 'option_auto_recording');
+        $field = new xmldb_field('registration', XMLDB_TYPE_INTEGER, '1', null, null, null, null, 'option_auto_recording');
         if (!$dbman->field_exists($table, $field)) {
             $dbman->add_field($table, $field);
         }
@@ -855,7 +855,7 @@ function xmldb_zoom_upgrade($oldversion) {
         $field = new xmldb_field('show_media', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '1', 'show_security');
         $dbman->change_field_notnull($table, $field);
 
-        $field = new xmldb_field('option_auto_recording', XMLDB_TYPE_CHAR, '5', null, XMLDB_NOTNULL, null, 'none', 'show_media');
+        $field = new xmldb_field('option_auto_recording', XMLDB_TYPE_CHAR, '5', null, null, null, null, 'show_media');
         $dbman->change_field_type($table, $field);
 
         // Zoom savepoint reached.

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -735,7 +735,8 @@ function xmldb_zoom_upgrade($oldversion) {
         $table = new xmldb_table('zoom');
 
         // Define and conditionally add field show_schedule.
-        $field = new xmldb_field('show_schedule', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '1', 'recordings_visible_default');
+        $field = new xmldb_field('show_schedule', XMLDB_TYPE_INTEGER, '1',
+            null, XMLDB_NOTNULL, null, '1', 'recordings_visible_default');
         if (!$dbman->field_exists($table, $field)) {
             $dbman->add_field($table, $field);
         }
@@ -842,10 +843,10 @@ function xmldb_zoom_upgrade($oldversion) {
     if ($oldversion < 2023080202) {
         // Issue #432: Inconsistency between the DB and schema, this is to verify everything matches.
         // Verify show_schedule, show_security, and show_media are all set to NOTNULL.
-        // Verify option_auto_record is set to NOTNULL and defaults to "none"
+        // Verify option_auto_record is set to NOTNULL and defaults to "none".
         $table = new xmldb_table('zoom');
 
-        // Launch change of nullability for show schedule
+        // Launch change of nullability for show schedule.
         $field = new xmldb_field('show_schedule', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '1', 'recordings_visible_default');
         $dbman->change_field_notnull($table, $field);
 

--- a/lib.php
+++ b/lib.php
@@ -346,9 +346,6 @@ function populate_zoom_from_response(stdClass $zoom, stdClass $response) {
     if (isset($response->settings->auto_recording)) {
         $newzoom->option_auto_recording = $response->settings->auto_recording;
     }
-    if (!isset($newzoom->option_auto_recording)) {
-        $newzoom->option_auto_recording = 'none';
-    }
 
     return $newzoom;
 }

--- a/mod_form.php
+++ b/mod_form.php
@@ -590,7 +590,7 @@ class mod_zoom_mod_form extends moodleform_mod {
             }
 
             if ($config->recordingoption === ZOOM_AUTORECORDING_USERDEFAULT) {
-                $defaultsetting = $recordingsettings;
+                $defaultsetting = $recordingsettings->auto_recording;
             } else {
                 $defaultsetting = $config->recordingoption;
             }

--- a/mod_form.php
+++ b/mod_form.php
@@ -589,8 +589,14 @@ class mod_zoom_mod_form extends moodleform_mod {
                 $options[ZOOM_AUTORECORDING_CLOUD] = get_string('autorecording_cloud', 'mod_zoom');
             }
 
+            if ($config->recordingoption === ZOOM_AUTORECORDING_USERDEFAULT) {
+                $defaultsetting = $recordingsettings;
+            } else {
+                $defaultsetting = $config->recordingoption;
+            }
+
             $mform->addElement('select', 'option_auto_recording', get_string('option_auto_recording', 'mod_zoom'), $options);
-            $mform->setDefault('option_auto_recording', $config->recordingoption);
+            $mform->setDefault('option_auto_recording', $defaultsetting);
             $mform->addHelpButton('option_auto_recording', 'option_auto_recording', 'mod_zoom');
         }
 

--- a/settings.php
+++ b/settings.php
@@ -355,7 +355,7 @@ if ($ADMIN->fulltree) {
     $recordingoption = new admin_setting_configselect('zoom/recordingoption',
         get_string('option_auto_recording', 'mod_zoom'),
         get_string('option_auto_recording_help', 'mod_zoom'),
-        ZOOM_AUTORECORDING_NONE, $autorecordingchoices);
+        ZOOM_AUTORECORDING_USERDEFAULT, $autorecordingchoices);
     $settings->add($recordingoption);
 
     $allowrecordingchangeoption = new admin_setting_configcheckbox('zoom/allowrecordingchangeoption',

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_zoom';
-$plugin->version = 2023070300;
-$plugin->release = 'v5.0.0';
+$plugin->version = 2023080202;
+$plugin->release = 'v5.0.1';
 $plugin->requires = 2019052000;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->cron = 0;


### PR DESCRIPTION
Working to Fix #432 and Fix #416

- Changes made to upgrade.php to assure show_schedule, show_security, and show_media are all set to NOTNULL, matching the schema.
- Changes to the schema to remove the default and NOTNULL from option_auto_recording
- Changed the site-level default setting for auto-recording to USERDEFAULT
- Handle USERDEFAULT in mod_form