### PR TITLE
recordings: use type codes, not language strings

### DIFF
--- a/classes/task/get_meeting_recordings.php
+++ b/classes/task/get_meeting_recordings.php
@@ -74,8 +74,8 @@ class get_meeting_recordings extends \core\task\scheduled_task {
         mtrace('Finding meeting recordings for this account...');
 
         $recordingtypestrings = [
-            'audio' => trim(get_string('recordingtypeaudio', 'mod_zoom')),
-            'video' => trim(get_string('recordingtypevideo', 'mod_zoom')),
+            'audio' => get_string('recordingtypeaudio', 'mod_zoom'),
+            'video' => get_string('recordingtypevideo', 'mod_zoom'),
         ];
 
         $zoommeetings = zoom_get_all_meeting_records();

--- a/classes/task/get_meeting_recordings.php
+++ b/classes/task/get_meeting_recordings.php
@@ -73,6 +73,11 @@ class get_meeting_recordings extends \core\task\scheduled_task {
 
         mtrace('Finding meeting recordings for this account...');
 
+        $recordingtypestrings = [
+            'audio' => trim(get_string('recordingtypeaudio', 'mod_zoom')),
+            'video' => trim(get_string('recordingtypevideo', 'mod_zoom')),
+        ];
+
         $zoommeetings = zoom_get_all_meeting_records();
         foreach ($zoommeetings as $zoom) {
             // Only get recordings for this meeting if its recurring or already finished.
@@ -91,14 +96,16 @@ class get_meeting_recordings extends \core\task\scheduled_task {
                                 continue;
                             }
 
+                            $recordingtypestring = $recordingtypestrings[$zoomrecordinginfo->recordingtype];
+
                             $rec = new \stdClass();
                             $rec->zoomid = $zoom->id;
                             $rec->meetinguuid = trim($zoomrecordinginfo->meetinguuid);
                             $rec->zoomrecordingid = trim($zoomrecordinginfo->recordingid);
-                            $rec->name = trim($zoom->name) . ' (' . trim($zoomrecordinginfo->recordingtype) . ')';
+                            $rec->name = trim($zoom->name) . ' (' . $recordingtypestring . ')';
                             $rec->externalurl = $zoomrecordinginfo->url;
                             $rec->passcode = trim($zoomrecordinginfo->passcode);
-                            $rec->recordingtype = trim($zoomrecordinginfo->recordingtype);
+                            $rec->recordingtype = $zoomrecordinginfo->recordingtype;
                             $rec->recordingstart = $recordingstarttime;
                             $rec->showrecording = $zoom->recordings_visible_default;
                             $rec->timecreated = $now;

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -962,6 +962,8 @@ class mod_zoom_webservice {
                 $settingsresponse = $this->make_call($settingsurl);
                 foreach ($response->recording_files as $rec) {
                     if (!empty($rec->play_url) && in_array($rec->file_type, $allowedrecordingtypes, true)) {
+                        $type = (!empty($rec->recording_type) && $rec->recording_type === 'audio_only') ? 'audio' : 'video';
+
                         // Only pick the video recording and audio only recordings.
                         // The transcript is available in both of these, so the extra file is unnecessary.
                         $recordinginfo = new stdClass();
@@ -969,9 +971,7 @@ class mod_zoom_webservice {
                         $recordinginfo->meetinguuid = $rec->meeting_id;
                         $recordinginfo->url = $rec->play_url;
                         $recordinginfo->filetype = $rec->file_type;
-                        $recordinginfo->recordingtype = (!empty($rec->recording_type) && $rec->recording_type === 'audio_only') ?
-                            get_string('recordingtypeaudio', 'mod_zoom') :
-                            get_string('recordingtypevideo', 'mod_zoom');
+                        $recordinginfo->recordingtype = $recordingtype;
                         $recordinginfo->passcode = $settingsresponse->password;
                         $recordings[strtotime($rec->recording_start)][] = $recordinginfo;
                     }


### PR DESCRIPTION
Previously it was storing the language strings in the database instead of the type code {audio, video} and using the language string with mtrace().

I would also like to remove the trim() on the get_string(), because we should probably be able to trust language strings won't have unnecessary space. Thoughts?