### PR TITLE
tests: define class properties (PHP 8.2)

### DIFF
--- a/tests/mod_zoom_grade_test.php
+++ b/tests/mod_zoom_grade_test.php
@@ -31,6 +31,26 @@ use advanced_testcase;
  */
 class mod_zoom_grade_test extends advanced_testcase {
     /**
+     * @var \stdClass Course record.
+     */
+    private $course;
+
+    /**
+     * @var \stdClass User record for teacher.
+     */
+    private $teacher;
+
+    /**
+     * @var \stdClass User record for student.
+     */
+    private $student;
+
+    /**
+     * @var \mod_zoom_generator Plugin generator for tests.
+     */
+    private $generator;
+
+    /**
      * Setup to ensure that fixtures are loaded.
      */
     public static function setUpBeforeClass(): void {

--- a/tests/mod_zoom_webservice_test.php
+++ b/tests/mod_zoom_webservice_test.php
@@ -35,6 +35,11 @@ use zoom_api_retry_failed_exception;
  */
 class mod_zoom_webservice_test extends advanced_testcase {
     /**
+     * @var object Anonymous class to mock \curl.
+     */
+    private $notfoundmockcurl;
+
+    /**
      * Setup to ensure that fixtures are loaded.
      */
     public static function setUpBeforeClass(): void {


### PR DESCRIPTION
When running the tests on a PHP 8.2 system with `display_errors` on, deprecated messages showed up.