### PR TITLE
remove date and time display on course page for no fixed time meetings

### DIFF
--- a/classes/dates.php
+++ b/classes/dates.php
@@ -45,30 +45,33 @@ class dates extends activity_dates {
         $duration = $this->cm->customdata['duration'] ?? null;
         $recurring = $this->cm->customdata['recurring'] ?? null;
         $recurrencetype = $this->cm->customdata['recurrence_type'] ?? null;
-        $now = time();
+
+        // For meeting with no fixed time, no time info needed on course page.
+        if ($recurring && $recurrencetype == \ZOOM_RECURRINGTYPE_NOTIME) {
+            return [];
+        }
+
         $dates = [];
 
         if ($starttime) {
-            // For meeting with no fixed time, no time info needed on course page.
-            if (!($recurring == 1 && $recurrencetype == 0)) {
-                if ($duration && $starttime + $duration < $now) {
-                    // Meeting has ended.
-                    $dataid = 'end_date_time';
-                    $labelid = 'activitydate:ended';
-                    $meetimgtimestamp = $starttime + $duration;
-                } else {
-                    // Meeting hasn't started / in progress, or without fixed time (doesn't have an end date or time).
-                    $dataid = 'start_time';
-                    $labelid = $starttime > $now ? 'activitydate:starts' : 'activitydate:started';
-                    $meetimgtimestamp = $starttime;
-                }
-
-                $dates[] = [
-                    'dataid' => $dataid,
-                    'label' => get_string($labelid, 'mod_zoom'),
-                    'timestamp' => $meetimgtimestamp,
-                ];
+            $now = time();
+            if ($duration && $starttime + $duration < $now) {
+                // Meeting has ended.
+                $dataid = 'end_date_time';
+                $labelid = 'activitydate:ended';
+                $meetimgtimestamp = $starttime + $duration;
+            } else {
+                // Meeting hasn't started / in progress.
+                $dataid = 'start_time';
+                $labelid = $starttime > $now ? 'activitydate:starts' : 'activitydate:started';
+                $meetimgtimestamp = $starttime;
             }
+
+            $dates[] = [
+                'dataid' => $dataid,
+                'label' => get_string($labelid, 'mod_zoom'),
+                'timestamp' => $meetimgtimestamp,
+            ];
         }
 
         return $dates;

--- a/classes/dates.php
+++ b/classes/dates.php
@@ -43,27 +43,32 @@ class dates extends activity_dates {
     protected function get_dates(): array {
         $starttime = $this->cm->customdata['start_time'] ?? null;
         $duration = $this->cm->customdata['duration'] ?? null;
+        $recurring = $this->cm->customdata['recurring'] ?? null;
+        $recurrencetype = $this->cm->customdata['recurrence_type'] ?? null;
         $now = time();
         $dates = [];
 
         if ($starttime) {
-            if ($duration && $starttime + $duration < $now) {
-                // Meeting has ended.
-                $dataid = 'end_date_time';
-                $labelid = 'activitydate:ended';
-                $meetimgtimestamp = $starttime + $duration;
-            } else {
-                // Meeting hasn't started / in progress, or without fixed time (doesn't have an end date or time).
-                $dataid = 'start_time';
-                $labelid = $starttime > $now ? 'activitydate:starts' : 'activitydate:started';
-                $meetimgtimestamp = $starttime;
-            }
+            // For meeting with no fixed time, no time info needed on course page.
+            if (!($recurring == 1 && $recurrencetype == 0)) {
+                if ($duration && $starttime + $duration < $now) {
+                    // Meeting has ended.
+                    $dataid = 'end_date_time';
+                    $labelid = 'activitydate:ended';
+                    $meetimgtimestamp = $starttime + $duration;
+                } else {
+                    // Meeting hasn't started / in progress, or without fixed time (doesn't have an end date or time).
+                    $dataid = 'start_time';
+                    $labelid = $starttime > $now ? 'activitydate:starts' : 'activitydate:started';
+                    $meetimgtimestamp = $starttime;
+                }
 
-            $dates[] = [
-                'dataid' => $dataid,
-                'label' => get_string($labelid, 'mod_zoom'),
-                'timestamp' => $meetimgtimestamp,
-            ];
+                $dates[] = [
+                    'dataid' => $dataid,
+                    'label' => get_string($labelid, 'mod_zoom'),
+                    'timestamp' => $meetimgtimestamp,
+                ];
+            }
         }
 
         return $dates;

--- a/lib.php
+++ b/lib.php
@@ -1315,7 +1315,6 @@ function zoom_get_coursemodule_info($coursemodule) {
 
     // Skip the if condition for recurring and recurrence_type, the values of NULL and 0 are needed in other functions.
     $result->customdata['recurring'] = $zoom->recurring;
-
     $result->customdata['recurrence_type'] = $zoom->recurrence_type;
 
     return $result;
@@ -1341,7 +1340,7 @@ function zoom_cm_info_dynamic(cm_info $cm) {
 
         // For unfinished meetings, override start_time with the next occurrence.
         // If this is a recurring meeting without fixed time, do not override - it will set start_time = 0.
-        if (!$finished && $moduleinstance->recurrence_type != 0) {
+        if (!$finished && $moduleinstance->recurrence_type != ZOOM_RECURRINGTYPE_NOTIME) {
             $cm->override_customdata('start_time', zoom_get_next_occurrence($moduleinstance));
         }
     }

--- a/lib.php
+++ b/lib.php
@@ -1292,7 +1292,7 @@ function zoom_get_coursemodule_info($coursemodule) {
     global $DB;
 
     $dbparams = ['id' => $coursemodule->instance];
-    $fields = 'id, intro, introformat, start_time, duration';
+    $fields = 'id, intro, introformat, start_time, recurring, recurrence_type, duration';
     if (!$zoom = $DB->get_record('zoom', $dbparams, $fields)) {
         return false;
     }
@@ -1312,6 +1312,11 @@ function zoom_get_coursemodule_info($coursemodule) {
     if ($zoom->duration) {
         $result->customdata['duration'] = $zoom->duration;
     }
+
+    // Skip the if condition for recurring and recurrence_type, the values of NULL and 0 are needed in other functions.
+    $result->customdata['recurring'] = $zoom->recurring;
+
+    $result->customdata['recurrence_type'] = $zoom->recurrence_type;
 
     return $result;
 }


### PR DESCRIPTION
Fixes #528 

The enhancement of meeting date and time display on course page was introduced in #493, but no fixed time meetings actually don't need it since they are supposed to keep going without an end time, and it's redundant to show the start time.