### PR TITLE
ci: check Moodle 4.3, PHP 8.2, strict phpdoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: '8.1'
+          - php: '8.2'
             moodle-branch: 'master'
             database: 'mariadb'
+          - php: '8.2'
+            moodle-branch: 'MOODLE_403_STABLE'
+            database: 'pgsql'
           - php: '8.1'
             moodle-branch: 'MOODLE_402_STABLE'
-            database: 'pgsql'
+            database: 'mariadb'
           - php: '8.0'
             moodle-branch: 'MOODLE_401_STABLE'
             database: 'pgsql'
@@ -82,6 +85,7 @@ jobs:
           echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
 
       - name: Install moodle-plugin-ci
+        id: install_ci
         run: |
           moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
         env:
@@ -90,49 +94,57 @@ jobs:
           MUSTACHE_IGNORE_NAMES: 'mobile_view_page_latest.mustache,mobile_view_page_ionic3.mustache'
 
       - name: PHP Lint
-        if: ${{ always() }}
+        if: ${{ !cancelled() && steps.install_ci.outcome == 'success' }}
         run: moodle-plugin-ci phplint
 
       - name: PHP Copy/Paste Detector
         continue-on-error: true # This step will show errors but will not fail
-        if: ${{ always() }}
+        if: ${{ !cancelled() && steps.install_ci.outcome == 'success' }}
         run: moodle-plugin-ci phpcpd
 
       - name: PHP Mess Detector
         continue-on-error: true # This step will show errors but will not fail
-        if: ${{ always() }}
+        if: ${{ !cancelled() && steps.install_ci.outcome == 'success' }}
         run: moodle-plugin-ci phpmd
 
       - name: Moodle Code Checker
-        if: ${{ always() }}
+        if: ${{ !cancelled() && steps.install_ci.outcome == 'success' }}
         run: moodle-plugin-ci codechecker --max-warnings 0
 
       - name: Moodle PHPDoc Checker
-        if: ${{ always() }}
+        if: ${{ !cancelled() && steps.install_ci.outcome == 'success' && matrix.php >= '7.4' }}
+        run: moodle-plugin-ci phpdoc --max-warnings 0
+
+      - name: Moodle PHPDoc Checker v3
+        if: ${{ !cancelled() && steps.install_ci.outcome == 'success' && matrix.php < '7.4' }}
         run: moodle-plugin-ci phpdoc
 
       - name: Validating
-        if: ${{ always() }}
+        if: ${{ !cancelled() && steps.install_ci.outcome == 'success' }}
         run: moodle-plugin-ci validate
 
       - name: Check upgrade savepoints
-        if: ${{ always() }}
+        if: ${{ !cancelled() && steps.install_ci.outcome == 'success' }}
         run: moodle-plugin-ci savepoints
 
       - name: Mustache Lint
-        if: ${{ always() }}
+        if: ${{ !cancelled() && steps.install_ci.outcome == 'success' }}
         run: moodle-plugin-ci mustache
 
       - name: Grunt
-        if: ${{ always() }}
+        if: ${{ !cancelled() && steps.install_ci.outcome == 'success' }}
         run: moodle-plugin-ci grunt --max-lint-warnings 0 || [ "$MOODLE_BRANCH" = 'MOODLE_39_STABLE' ] || [ "$MOODLE_BRANCH" = 'MOODLE_311_STABLE' ]
         env:
           MOODLE_BRANCH: ${{ matrix.moodle-branch }}
 
       - name: PHPUnit tests
-        if: ${{ always() }}
+        if: ${{ !cancelled() && steps.install_ci.outcome == 'success' }}
         run: moodle-plugin-ci phpunit --fail-on-warning
 
       - name: Behat features
-        if: ${{ always() }}
+        if: ${{ !cancelled() && steps.install_ci.outcome == 'success' }}
         run: moodle-plugin-ci behat --profile chrome
+
+      - name: Make sure cancelled jobs are marked as failures.
+        if: ${{ cancelled() }}
+        run: exit 1


### PR DESCRIPTION
- Add Moodle 4.3
- Use PHP 8.2 for 4.3 and newer
- Only run moodle-plugin-ci steps when the moodle-plugin-ci installs successfully
- On moodle-plugin-ci v4, set `--max-warnings 0` for phpdoc
- If the job has been cancelled, mark the job as failed so that PR status checks cannot be bypassed
- Use `!cancelled()` instead of `always()` as recommended by GitHub

From https://docs.github.com/en/actions/learn-github-actions/expressions#always

> If you want to run a job or step regardless of its success or failure, use the recommended alternative: `if: ${{ !cancelled() }}`