### PR TITLE
calendar: skip calendar permissions check

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -550,7 +550,7 @@ function zoom_calendar_item_update(stdClass $zoom) {
 
     // Any remaining events in the array don't exist on Moodle, so create a new event.
     foreach ($newevents as $uuid => $newevent) {
-        calendar_event::create($newevent);
+        calendar_event::create($newevent, false);
     }
 }
 


### PR DESCRIPTION
Permissions have already been checked by the calling functions/tasks.

Fixes #534 