### PR TITLE
Fix: restore try catch namespace

### DIFF
--- a/backup/moodle2/restore_zoom_stepslib.php
+++ b/backup/moodle2/restore_zoom_stepslib.php
@@ -29,6 +29,7 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot . '/mod/zoom/locallib.php');
 
+use moodle_exception;
 use restore_path_element;
 
 /**

--- a/classes/analytics/indicator/activity_base.php
+++ b/classes/analytics/indicator/activity_base.php
@@ -24,10 +24,12 @@
 
 namespace mod_zoom\analytics\indicator;
 
+use core_analytics\local\indicator\community_of_inquiry_activity;
+
 /**
  * Activity base class.
  */
-abstract class activity_base extends \core_analytics\local\indicator\community_of_inquiry_activity {
+abstract class activity_base extends community_of_inquiry_activity {
     /**
      * Grading not implemented.
      *

--- a/classes/analytics/indicator/cognitive_depth.php
+++ b/classes/analytics/indicator/cognitive_depth.php
@@ -24,6 +24,9 @@
 
 namespace mod_zoom\analytics\indicator;
 
+use cm_info;
+use lang_string;
+
 /**
  * Cognitive depth indicator - zoom.
  */
@@ -33,8 +36,8 @@ class cognitive_depth extends activity_base {
      *
      * @return object
      */
-    public static function get_name(): \lang_string {
-        return new \lang_string('indicator:cognitivedepth', 'mod_zoom');
+    public static function get_name(): lang_string {
+        return new lang_string('indicator:cognitivedepth', 'mod_zoom');
     }
 
     /**
@@ -53,7 +56,7 @@ class cognitive_depth extends activity_base {
      *
      * @return integer
      */
-    public function get_cognitive_depth_level(\cm_info $cm) {
+    public function get_cognitive_depth_level(cm_info $cm) {
         return self::COGNITIVE_LEVEL_1;
     }
 }

--- a/classes/analytics/indicator/social_breadth.php
+++ b/classes/analytics/indicator/social_breadth.php
@@ -24,6 +24,9 @@
 
 namespace mod_zoom\analytics\indicator;
 
+use cm_info;
+use lang_string;
+
 /**
  * Social breadth indicator.
  */
@@ -35,8 +38,8 @@ class social_breadth extends activity_base {
      *
      * @return object
      */
-    public static function get_name(): \lang_string {
-        return new \lang_string('indicator:socialbreadth', 'mod_zoom');
+    public static function get_name(): lang_string {
+        return new lang_string('indicator:socialbreadth', 'mod_zoom');
     }
 
     /**
@@ -55,7 +58,7 @@ class social_breadth extends activity_base {
      *
      * @return integer
      */
-    public function get_social_breadth_level(\cm_info $cm) {
+    public function get_social_breadth_level(cm_info $cm) {
         return self::SOCIAL_LEVEL_2;
     }
 }

--- a/classes/api_limit_exception.php
+++ b/classes/api_limit_exception.php
@@ -24,6 +24,8 @@
 
 namespace mod_zoom;
 
+use stdClass;
+
 /**
  * Exceeded daily API limit.
  */
@@ -43,7 +45,7 @@ class api_limit_exception extends webservice_exception {
     public function __construct($response, $errorcode, $retryafter) {
         $this->retryafter = $retryafter;
 
-        $a = new \stdClass();
+        $a = new stdClass();
         $a->response = $response;
         parent::__construct(
             $response,

--- a/classes/event/join_meeting_button_clicked.php
+++ b/classes/event/join_meeting_button_clicked.php
@@ -24,6 +24,9 @@
 
 namespace mod_zoom\event;
 
+use coding_exception;
+use moodle_url;
+
 /**
  * Records when a join meeting button is clicked.
  */
@@ -44,9 +47,9 @@ class join_meeting_button_clicked extends \core\event\base {
         $fieldstovalidate = ['cmid' => "integer", 'meetingid' => "integer", 'userishost' => "boolean"];
         foreach ($fieldstovalidate as $field => $shouldbe) {
             if (is_null($this->other[$field])) {
-                throw new \coding_exception("The $field value must be set in other.");
+                throw new coding_exception("The $field value must be set in other.");
             } else if (gettype($this->other[$field]) != $shouldbe) {
-                throw new \coding_exception("The $field value must be an $shouldbe.");
+                throw new coding_exception("The $field value must be an $shouldbe.");
             }
         }
     }
@@ -76,6 +79,6 @@ class join_meeting_button_clicked extends \core\event\base {
      * @return moodle_url
      */
     public function get_url() {
-        return new \moodle_url('/mod/zoom/view.php', ['id' => $this->other['cmid']]);
+        return new moodle_url('/mod/zoom/view.php', ['id' => $this->other['cmid']]);
     }
 }

--- a/classes/invitation.php
+++ b/classes/invitation.php
@@ -25,6 +25,10 @@
 
 namespace mod_zoom;
 
+use coding_exception;
+use context_module;
+use moodle_exception;
+
 /**
  * Invitation class.
  */
@@ -81,11 +85,11 @@ class invitation {
             }
 
             // Check user capabilities, and remove parts of the invitation they don't have permission to view.
-            if (!has_capability('mod/zoom:viewjoinurl', \context_module::instance($coursemoduleid), $userid)) {
+            if (!has_capability('mod/zoom:viewjoinurl', context_module::instance($coursemoduleid), $userid)) {
                 $displaystring = $this->remove_element($displaystring, 'joinurl');
             }
 
-            if (!has_capability('mod/zoom:viewdialin', \context_module::instance($coursemoduleid), $userid)) {
+            if (!has_capability('mod/zoom:viewdialin', context_module::instance($coursemoduleid), $userid)) {
                 $displaystring = $this->remove_element($displaystring, 'onetapmobile');
                 $displaystring = $this->remove_element($displaystring, 'dialin');
                 $displaystring = $this->remove_element($displaystring, 'sip');
@@ -94,7 +98,7 @@ class invitation {
                 // Fix the formatting of the onetapmobile section if it exists.
                 $displaystring = $this->add_paragraph_break_above_element($displaystring, 'onetapmobile');
             }
-        } catch (\moodle_exception $e) {
+        } catch (moodle_exception $e) {
             // If the regex parsing fails, log a debugging message and return the whole invitation.
             debugging($e->getMessage(), DEBUG_DEVELOPER);
             return $this->invitation;
@@ -120,7 +124,7 @@ class invitation {
 
         $configregex = $this->get_config_invitation_regex();
         if (!array_key_exists($element, $configregex)) {
-            throw new \coding_exception('Cannot remove element: ' . $element
+            throw new coding_exception('Cannot remove element: ' . $element
                     . '. See mod/zoom/classes/invitation.php:get_default_invitation_regex for valid elements.');
         }
 
@@ -134,7 +138,7 @@ class invitation {
 
         // If invitation is null, an error occurred in preg_replace.
         if ($invitation === null) {
-            throw new \moodle_exception(
+            throw new moodle_exception(
                 'invitationmodificationfailed',
                 'mod_zoom',
                 $PAGE->url,

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -25,20 +25,22 @@
 
 namespace mod_zoom\privacy;
 
+use core_privacy\local\metadata\collection;
+use core_privacy\local\metadata\provider as metadata_provider;
+use core_privacy\local\request\core_userlist_provider;
+use core_privacy\local\request\plugin\provider as request_plugin_provider;
+
 /**
  * Ad hoc task that performs the actions for approved data privacy requests.
  */
-class provider implements
-    \core_privacy\local\request\core_userlist_provider,
-    \core_privacy\local\metadata\provider,
-    \core_privacy\local\request\plugin\provider {
+class provider implements core_userlist_provider, metadata_provider, request_plugin_provider {
     /**
      * Returns meta data about this system.
      *
      * @param   collection $coll The collection to add metadata to.
      * @return  collection  The array of metadata
      */
-    public static function get_metadata(\core_privacy\local\metadata\collection $coll): \core_privacy\local\metadata\collection {
+    public static function get_metadata(collection $coll): collection {
         // Add all user data fields to the collection.
 
         $coll->add_database_table('zoom_meeting_participants', [

--- a/classes/retry_failed_exception.php
+++ b/classes/retry_failed_exception.php
@@ -24,6 +24,8 @@
 
 namespace mod_zoom;
 
+use stdClass;
+
 /**
  * Couldn't succeed within the allowed number of retries.
  */
@@ -34,7 +36,7 @@ class retry_failed_exception extends webservice_exception {
      * @param int $errorcode     Web service response error code
      */
     public function __construct($response, $errorcode) {
-        $a = new \stdClass();
+        $a = new stdClass();
         $a->response = $response;
         $a->maxretries = webservice::MAX_RETRIES;
         parent::__construct($response, $errorcode, 'zoomerr_maxretries', 'mod_zoom', '', $a);

--- a/classes/search/activity.php
+++ b/classes/search/activity.php
@@ -24,10 +24,12 @@
 
 namespace mod_zoom\search;
 
+use core_search\base_activity;
+
 /**
  * Search area for mod_zoom activities.
  */
-class activity extends \core_search\base_activity {
+class activity extends base_activity {
     /**
      * Returns true if this area uses file indexing.
      *

--- a/classes/task/delete_meeting_recordings.php
+++ b/classes/task/delete_meeting_recordings.php
@@ -29,10 +29,13 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot . '/mod/zoom/locallib.php');
 
+use core\task\scheduled_task;
+use moodle_exception;
+
 /**
  * Scheduled task to delete meeting recordings from Moodle.
  */
-class delete_meeting_recordings extends \core\task\scheduled_task {
+class delete_meeting_recordings extends scheduled_task {
     /**
      * Returns name of task.
      *
@@ -52,7 +55,7 @@ class delete_meeting_recordings extends \core\task\scheduled_task {
 
         try {
             $service = zoom_webservice();
-        } catch (\moodle_exception $exception) {
+        } catch (moodle_exception $exception) {
             mtrace('Skipping task - ', $exception->getMessage());
             return;
         }

--- a/classes/task/get_meeting_recordings.php
+++ b/classes/task/get_meeting_recordings.php
@@ -29,12 +29,14 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot . '/mod/zoom/locallib.php');
 
+use core\task\scheduled_task;
 use moodle_exception;
+use stdClass;
 
 /**
  * Scheduled task to get the meeting recordings.
  */
-class get_meeting_recordings extends \core\task\scheduled_task {
+class get_meeting_recordings extends scheduled_task {
     /**
      * Returns name of task.
      *
@@ -133,7 +135,7 @@ class get_meeting_recordings extends \core\task\scheduled_task {
                 $recordingtype = $recording->recordingtype;
                 $recordingtypestring = $recordingtypestrings[$recordingtype];
 
-                $record = new \stdClass();
+                $record = new stdClass();
                 $record->zoomid = $zoom->id;
                 $record->meetinguuid = $recording->meetinguuid;
                 $record->zoomrecordingid = $recordingid;

--- a/classes/task/get_meeting_recordings.php
+++ b/classes/task/get_meeting_recordings.php
@@ -29,6 +29,8 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot . '/mod/zoom/locallib.php');
 
+use moodle_exception;
+
 /**
  * Scheduled task to get the meeting recordings.
  */
@@ -52,7 +54,7 @@ class get_meeting_recordings extends \core\task\scheduled_task {
 
         try {
             $service = zoom_webservice();
-        } catch (\moodle_exception $exception) {
+        } catch (moodle_exception $exception) {
             mtrace('Skipping task - ', $exception->getMessage());
             return;
         }

--- a/classes/task/update_tracking_fields.php
+++ b/classes/task/update_tracking_fields.php
@@ -29,10 +29,13 @@ defined('MOODLE_INTERNAL') || die();
 require_once($CFG->dirroot . '/mod/zoom/lib.php');
 require_once($CFG->dirroot . '/mod/zoom/locallib.php');
 
+use core\task\scheduled_task;
+use moodle_exception;
+
 /**
  * Scheduled task to sychronize tracking field data.
  */
-class update_tracking_fields extends \core\task\scheduled_task {
+class update_tracking_fields extends scheduled_task {
     /**
      * Returns name of task.
      *
@@ -50,7 +53,7 @@ class update_tracking_fields extends \core\task\scheduled_task {
     public function execute() {
         try {
             zoom_webservice();
-        } catch (\moodle_exception $exception) {
+        } catch (moodle_exception $exception) {
             mtrace('Skipping task - ', $exception->getMessage());
             return;
         }

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -29,6 +29,9 @@ defined('MOODLE_INTERNAL') || die();
 require_once($CFG->dirroot . '/mod/zoom/locallib.php');
 require_once($CFG->libdir . '/filelib.php');
 
+use cache;
+use core_user;
+use curl;
 use moodle_exception;
 use stdClass;
 
@@ -205,7 +208,7 @@ class webservice {
         }
 
         // Create $curl, which implicitly uses the proxy settings from $CFG.
-        $curl = new \curl();
+        $curl = new curl();
 
         if (!empty($proxyhost)) {
             // Restore the stored global proxy settings from above.
@@ -430,7 +433,7 @@ class webservice {
         foreach ($userslist as $user) {
             if ($user->type != ZOOM_USER_TYPE_BASIC) {
                 // Count the user if we're including all users or if the user is on this instance.
-                if (!$this->instanceusers || \core_user::get_user_by_email($user->email)) {
+                if (!$this->instanceusers || core_user::get_user_by_email($user->email)) {
                     $numusers++;
                     if ($numusers >= $this->numlicenses) {
                         return true;
@@ -453,7 +456,7 @@ class webservice {
         foreach ($userslist as $user) {
             if ($user->type != ZOOM_USER_TYPE_BASIC && isset($user->last_login_time)) {
                 // Count the user if we're including all users or if the user is on this instance.
-                if (!$this->instanceusers || \core_user::get_user_by_email($user->email)) {
+                if (!$this->instanceusers || core_user::get_user_by_email($user->email)) {
                     $usertimes[$user->id] = strtotime($user->last_login_time);
                 }
             }
@@ -1076,7 +1079,7 @@ class webservice {
      * @return string access token
      */
     protected function get_access_token() {
-        $cache = \cache::make('mod_zoom', 'oauth');
+        $cache = cache::make('mod_zoom', 'oauth');
         $token = $cache->get('accesstoken');
         $expires = $cache->get('expires');
         if (empty($token) || empty($expires) || time() >= $expires) {

--- a/classes/webservice_exception.php
+++ b/classes/webservice_exception.php
@@ -24,10 +24,12 @@
 
 namespace mod_zoom;
 
+use moodle_exception;
+
 /**
  * Webservice exception class.
  */
-class webservice_exception extends \moodle_exception {
+class webservice_exception extends moodle_exception {
     /**
      * Web service response.
      * @var string

--- a/tests/mod_zoom_invitation_test.php
+++ b/tests/mod_zoom_invitation_test.php
@@ -58,7 +58,7 @@ class mod_zoom_invitation_test extends advanced_testcase {
         $this->setAdminUser();
         $course = $this->getDataGenerator()->create_course();
         $zoom = $this->getDataGenerator()->create_module('zoom', ['course' => $course]);
-        $message = (new \mod_zoom\invitation(
+        $message = (new invitation(
             $this->get_mock_invitation_message_scheduledmeeting()
         ))->get_display_string($zoom->cmid);
         $expectedmessage = "Organization is inviting you to a scheduled Zoom meeting.\r\n"
@@ -121,7 +121,7 @@ class mod_zoom_invitation_test extends advanced_testcase {
         $zoom = $this->getDataGenerator()->create_module('zoom', ['course' => $course]);
         assign_capability('mod/zoom:viewjoinurl', CAP_ALLOW, $role, context_system::instance()->id);
         role_assign($role, $user->id, context_course::instance($course->id));
-        $message = (new \mod_zoom\invitation(
+        $message = (new invitation(
             $this->get_mock_invitation_message_scheduledmeeting()
         ))->get_display_string($zoom->cmid, $user->id);
         $expectedmessage = "Organization is inviting you to a scheduled Zoom meeting.\r\n"
@@ -149,7 +149,7 @@ class mod_zoom_invitation_test extends advanced_testcase {
         $zoom = $this->getDataGenerator()->create_module('zoom', ['course' => $course]);
         assign_capability('mod/zoom:viewdialin', CAP_ALLOW, $role, context_system::instance());
         role_assign($role, $user->id, context_course::instance($course->id));
-        $message = (new \mod_zoom\invitation(
+        $message = (new invitation(
             $this->get_mock_invitation_message_scheduledmeeting()
         ))->get_display_string($zoom->cmid, $user->id);
         $expectedmessage = "Organization is inviting you to a scheduled Zoom meeting.\r\n"
@@ -205,7 +205,7 @@ class mod_zoom_invitation_test extends advanced_testcase {
         $role = $this->getDataGenerator()->create_role();
         $zoom = $this->getDataGenerator()->create_module('zoom', ['course' => $course]);
         role_assign($role, $user->id, context_course::instance($course->id));
-        $message = (new \mod_zoom\invitation(
+        $message = (new invitation(
             $this->get_mock_invitation_message_scheduledmeeting()
         ))->get_display_string($zoom->cmid, $user->id);
         $expectedmessage = "Organization is inviting you to a scheduled Zoom meeting.\r\n"
@@ -230,7 +230,7 @@ class mod_zoom_invitation_test extends advanced_testcase {
         role_assign($role, $user->id, context_course::instance($course->id));
         // Set mock zoom activity URL for page as exception messages expect it.
         $PAGE->set_url(new moodle_url('/mod/zoom/view.php?id=123'));
-        $message = (new \mod_zoom\invitation(
+        $message = (new invitation(
             $this->get_mock_invitation_message_scheduledmeeting()
         ))->get_display_string($zoom->cmid, $user->id);
         $this->assertDebuggingNotCalled();
@@ -251,7 +251,7 @@ class mod_zoom_invitation_test extends advanced_testcase {
         role_assign($role, $user->id, context_course::instance($course->id));
         // Set mock zoom activity URL for page as exception messages expect it.
         $PAGE->set_url(new moodle_url('/mod/zoom/view.php?id=123'));
-        $message = (new \mod_zoom\invitation(
+        $message = (new invitation(
             $this->get_mock_invitation_message_scheduledmeeting()
         ))->get_display_string($zoom->cmid, $user->id);
         $this->assertDebuggingCalled('Error in regex for zoom invitation element: "joinurl" with pattern: "~".');
@@ -269,7 +269,7 @@ class mod_zoom_invitation_test extends advanced_testcase {
         $role = $this->getDataGenerator()->create_role();
         $zoom = $this->getDataGenerator()->create_module('zoom', ['course' => $course]);
         role_assign($role, $user->id, context_course::instance($course->id));
-        $message = (new \mod_zoom\invitation(
+        $message = (new invitation(
             $this->get_mock_invitation_message_scheduledmeeting()
         ))->get_display_string($zoom->cmid, $user->id);
         $this->assertDebuggingCalled('No match found in zoom invitation for element: "joinurl" with pattern: "/nomatch/mi".');
@@ -284,7 +284,7 @@ class mod_zoom_invitation_test extends advanced_testcase {
         set_config('invitationremoveinvite', '1', 'zoom');
         $course = $this->getDataGenerator()->create_course();
         $zoom = $this->getDataGenerator()->create_module('zoom', ['course' => $course]);
-        $message = (new \mod_zoom\invitation(
+        $message = (new invitation(
             $this->get_mock_invitation_message_scheduledmeeting()
         ))->get_display_string($zoom->cmid);
         $expectedmessage = "Topic: Zoom Meeting\r\n"
@@ -342,7 +342,7 @@ class mod_zoom_invitation_test extends advanced_testcase {
         set_config('invitationremoveinvite', '0', 'zoom');
         $course = $this->getDataGenerator()->create_course();
         $zoom = $this->getDataGenerator()->create_module('zoom', ['course' => $course]);
-        $message = (new \mod_zoom\invitation(
+        $message = (new invitation(
             $this->get_mock_invitation_message_scheduledmeeting()
         ))->get_display_string($zoom->cmid);
         $expectedmessage = "Organization is inviting you to a scheduled Zoom meeting.\r\n"
@@ -404,7 +404,7 @@ class mod_zoom_invitation_test extends advanced_testcase {
         $zoom = $this->getDataGenerator()->create_module('zoom', ['course' => $course]);
 
         // Test a scheduled meeting.
-        $message = (new \mod_zoom\invitation(
+        $message = (new invitation(
             $this->get_mock_invitation_message_scheduledmeeting()
         ))->get_display_string($zoom->cmid);
         $expectedmessage = "Organization is inviting you to a scheduled Zoom meeting.\r\n"
@@ -455,7 +455,7 @@ class mod_zoom_invitation_test extends advanced_testcase {
         $this->assertEquals($expectedmessage, $message);
 
         // Test a recurring meeting with no fixed time.
-        $message = (new \mod_zoom\invitation(
+        $message = (new invitation(
             $this->get_mock_invitation_message_recurringnofixed()
         ))->get_display_string($zoom->cmid);
         $expectedmessage = "Organization is inviting you to a scheduled Zoom meeting.\r\n"
@@ -506,7 +506,7 @@ class mod_zoom_invitation_test extends advanced_testcase {
         $this->assertEquals($expectedmessage, $message);
 
         // Test a recurring meeting with fixed time.
-        $message = (new \mod_zoom\invitation($this->get_mock_invitation_message_recurringfixed()))->get_display_string($zoom->cmid);
+        $message = (new invitation($this->get_mock_invitation_message_recurringfixed()))->get_display_string($zoom->cmid);
         $expectedmessage = "Organization is inviting you to a scheduled Zoom meeting.\r\n"
             . "\r\n"
             . "Topic: Zoom Meeting\r\n"
@@ -577,7 +577,7 @@ class mod_zoom_invitation_test extends advanced_testcase {
         $zoom = $this->getDataGenerator()->create_module('zoom', ['course' => $course]);
 
         // Test a scheduled meeting.
-        $message = (new \mod_zoom\invitation(
+        $message = (new invitation(
             $this->get_mock_invitation_message_scheduledmeeting()
         ))->get_display_string($zoom->cmid);
         $expectedmessage = "Organization is inviting you to a scheduled Zoom meeting.\r\n"
@@ -628,7 +628,7 @@ class mod_zoom_invitation_test extends advanced_testcase {
         $this->assertEquals($expectedmessage, $message);
 
         // Test a recurring meeting with no fixed time.
-        $message = (new \mod_zoom\invitation(
+        $message = (new invitation(
             $this->get_mock_invitation_message_recurringnofixed()
         ))->get_display_string($zoom->cmid);
         $expectedmessage = "Organization is inviting you to a scheduled Zoom meeting.\r\n"
@@ -679,7 +679,7 @@ class mod_zoom_invitation_test extends advanced_testcase {
         $this->assertEquals($expectedmessage, $message);
 
         // Test a recurring meeting with fixed time.
-        $message = (new \mod_zoom\invitation($this->get_mock_invitation_message_recurringfixed()))->get_display_string($zoom->cmid);
+        $message = (new invitation($this->get_mock_invitation_message_recurringfixed()))->get_display_string($zoom->cmid);
         $expectedmessage = "Organization is inviting you to a scheduled Zoom meeting.\r\n"
             . "\r\n"
             . "Topic: Zoom Meeting\r\n"
@@ -743,7 +743,7 @@ class mod_zoom_invitation_test extends advanced_testcase {
         $this->setAdminUser();
         $course = $this->getDataGenerator()->create_course();
         $zoom = $this->getDataGenerator()->create_module('zoom', ['course' => $course]);
-        $message = (new \mod_zoom\invitation(null))->get_display_string($zoom->cmid);
+        $message = (new invitation(null))->get_display_string($zoom->cmid);
         $this->assertNull($message);
     }
 
@@ -759,7 +759,7 @@ class mod_zoom_invitation_test extends advanced_testcase {
         $role = $this->getDataGenerator()->create_role();
         $zoom = $this->getDataGenerator()->create_module('zoom', ['course' => $course]);
         role_assign($role, $user->id, context_course::instance($course->id));
-        $message = (new \mod_zoom\invitation(
+        $message = (new invitation(
             $this->get_mock_invitation_message_scheduledmeeting()
         ))->get_display_string($zoom->cmid, $user->id);
         $expectedmessage = $this->get_mock_invitation_message_scheduledmeeting();

--- a/tests/privacy/mod_zoom_provider_test.php
+++ b/tests/privacy/mod_zoom_provider_test.php
@@ -23,6 +23,7 @@ use core_privacy\local\request\approved_userlist;
 use core_privacy\local\request\deletion_criteria;
 use core_privacy\local\request\userlist;
 use core_privacy\local\request\writer;
+use core_privacy\tests\provider_testcase;
 use mod_zoom\privacy\provider;
 
 /**
@@ -34,7 +35,7 @@ use mod_zoom\privacy\provider;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @coversDefaultClass \mod_zoom\privacy\provider
  */
-class mod_zoom_provider_test extends \core_privacy\tests\provider_testcase {
+class mod_zoom_provider_test extends provider_testcase {
     /** @var object The zoom instance object. */
     protected $zoominstance;
 


### PR DESCRIPTION
Fixes a regression in v5.1.1 where an exception during restore was not caught as a result of namespace issues. While we're here, make the namespaced files leverage `use` statements to simplify lengthy class references.