### PR TITLE
webservice: always initialize the OAuth scopes

### DIFF
--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -1084,6 +1084,8 @@ class webservice {
         $expires = $cache->get('expires');
         if (empty($token) || empty($expires) || time() >= $expires) {
             $token = $this->oauth($cache);
+        } else {
+            $this->scopes = $cache->get('scopes');
         }
 
         return $token;


### PR DESCRIPTION
The `$this->scopes` array is correctly initialized when `$this->oauth()` completes successfully. However, `has_scopes()` avoids calling that function directly so that the cached token can be reused. Unfortunately, I forgot to make sure that `$this->scopes` was being populated from the cache in those situations where the token was fresh and thus able to be reused. 😓 

Fixes #541 