### PR TITLE
release: v5.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ server is properly synchronized with the time servers.
 
 ## Changelog
 
+v5.1.2
+
+- Bugfix: Skip redundant calendar permissions check #535 (thanks @danowar2k)
+- Bugfix: Initialize scopes from cache to avoid TypeError #542 (thanks @foxlapinou)
+- Regression: Restore exceptions were not being caught #537
+  - Introduced in v5.1.1 when moving classes into namespaces.
+- Code quality: Void test return types in moodle-cs v3.3.10 #536
+
 v5.1.1
 
 - Bugfix: Get all meeting recordings, not just the last occurrence #517 (thanks @LGPoly)

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_zoom';
-$plugin->version = 2023101900;
-$plugin->release = 'v5.1.1';
+$plugin->version = 2023111000;
+$plugin->release = 'v5.1.2';
 $plugin->requires = 2019052000;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->cron = 0;


### PR DESCRIPTION
A few very important bug fixes, especially the "cache has a valid token, but the scopes cache isn't available to in_array" TypeError, and one code quality fix.