### PR TITLE
Fix: change recurrence type default option to "No Fixed Time"

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -204,12 +204,16 @@ class mod_zoom_mod_form extends moodleform_mod {
 
         // Add options for recurring meeting.
         $recurrencetype = [
-            ZOOM_RECURRINGTYPE_NOTIME => get_string('recurrence_option_no_time', 'zoom'),
             ZOOM_RECURRINGTYPE_DAILY => get_string('recurrence_option_daily', 'zoom'),
             ZOOM_RECURRINGTYPE_WEEKLY => get_string('recurrence_option_weekly', 'zoom'),
             ZOOM_RECURRINGTYPE_MONTHLY => get_string('recurrence_option_monthly', 'zoom'),
+            ZOOM_RECURRINGTYPE_NOTIME => get_string('recurrence_option_no_time', 'zoom'),
         ];
         $mform->addElement('select', 'recurrence_type', get_string('recurrencetype', 'zoom'), $recurrencetype);
+        // If the defaultrecurring option is active, set default recurrence_type to be No Fixed Time.
+        if ($config->defaultrecurring == 1) {
+            $mform->setDefault('recurrence_type', ZOOM_RECURRINGTYPE_NOTIME);
+        }
         $mform->hideif('recurrence_type', 'recurring', 'notchecked');
 
         // Repeat Interval options.

--- a/mod_form.php
+++ b/mod_form.php
@@ -204,10 +204,10 @@ class mod_zoom_mod_form extends moodleform_mod {
 
         // Add options for recurring meeting.
         $recurrencetype = [
+            ZOOM_RECURRINGTYPE_NOTIME => get_string('recurrence_option_no_time', 'zoom'),
             ZOOM_RECURRINGTYPE_DAILY => get_string('recurrence_option_daily', 'zoom'),
             ZOOM_RECURRINGTYPE_WEEKLY => get_string('recurrence_option_weekly', 'zoom'),
             ZOOM_RECURRINGTYPE_MONTHLY => get_string('recurrence_option_monthly', 'zoom'),
-            ZOOM_RECURRINGTYPE_NOTIME => get_string('recurrence_option_no_time', 'zoom'),
         ];
         $mform->addElement('select', 'recurrence_type', get_string('recurrencetype', 'zoom'), $recurrencetype);
         $mform->hideif('recurrence_type', 'recurring', 'notchecked');


### PR DESCRIPTION
Fixes #523 

When the Recurring Meeting checkbox is checked, the Recurrence dropdown below should have "No Fixed Time" as the default option. This simple fix should do the trick.