### PR TITLE
Allow editing description for existing meetings

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -1011,7 +1011,7 @@ class mod_zoom_mod_form extends moodleform_mod {
         // Only check for scheduled meetings.
         if (empty($data['recurring'])) {
             // Make sure start date is in the future.
-            if ($data['start_time'] < time()) {
+            if ($data['start_time'] < time() && $data['meeting_id'] < 0) {
                 $errors['start_time'] = get_string('err_start_time_past', 'zoom');
             }
 
@@ -1023,7 +1023,7 @@ class mod_zoom_mod_form extends moodleform_mod {
             }
         } else if ($data['recurring'] == 1 && $data['recurrence_type'] != ZOOM_RECURRINGTYPE_NOTIME) {
             // Make sure start date time (first potential date of next meeting) is in the future.
-            if ($data['start_time'] < time()) {
+            if ($data['start_time'] < time() && $data['meeting_id'] < 0) {
                 $errors['start_time'] = get_string('err_start_time_past_recurring', 'zoom');
             }
 


### PR DESCRIPTION
Skips "new activity" check to allow updating meeting descriptions for existing and past meetings. 
If necessary, a further edit could skip the "new activity" check if the meeting already exists AND if the meeting date/time hasn't changed.