### PR TITLE
db: remove start_url from zoom table

### DIFF
--- a/backup/moodle2/backup_zoom_stepslib.php
+++ b/backup/moodle2/backup_zoom_stepslib.php
@@ -40,7 +40,7 @@ class backup_activity_structure_step extends \backup_activity_structure_step {
     protected function define_structure() {
         // Define the root element describing the zoom instance.
         $zoom = new backup_nested_element('zoom', ['id'], [
-            'intro', 'introformat', 'grade', 'meeting_id', 'start_url', 'join_url', 'created_at', 'host_id', 'name',
+            'intro', 'introformat', 'grade', 'meeting_id', 'join_url', 'created_at', 'host_id', 'name',
             'start_time', 'timemodified', 'recurring', 'recurrence_type', 'repeat_interval', 'weekly_days', 'monthly_day',
             'monthly_week', 'monthly_week_day', 'monthly_repeat_option', 'end_times', 'end_date_time', 'end_date_option',
             'webinar', 'duration', 'timezone', 'password', 'option_jbh', 'option_start_type', 'option_host_video',

--- a/backup/moodle2/restore_zoom_stepslib.php
+++ b/backup/moodle2/restore_zoom_stepslib.php
@@ -69,7 +69,6 @@ class restore_activity_structure_step extends \restore_activity_structure_step {
             $data = populate_zoom_from_response($data, $updateddata);
             $data->exists_on_zoom = ZOOM_MEETING_EXISTS;
         } catch (moodle_exception $e) {
-            $data->start_url = '';
             $data->join_url = '';
             $data->meeting_id = 0;
             $data->exists_on_zoom = ZOOM_MEETING_EXPIRED;

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="mod/zoom/db" VERSION="20230803" COMMENT="Zoom module"
+<XMLDB PATH="mod/zoom/db" VERSION="20231116" COMMENT="Zoom module"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >

--- a/db/install.xml
+++ b/db/install.xml
@@ -12,7 +12,6 @@
         <FIELD NAME="introformat" TYPE="int" LENGTH="4" NOTNULL="false" SEQUENCE="false" COMMENT="Format of description field"/>
         <FIELD NAME="grade" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Maximum grade (points possible) for this activity. Negative value indicates a scale being used."/>
         <FIELD NAME="meeting_id" TYPE="int" LENGTH="15" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="start_url" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="join_url" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="created_at" TYPE="char" LENGTH="20" NOTNULL="false" SEQUENCE="false" COMMENT="ISO datetime format"/>
         <FIELD NAME="host_id" TYPE="char" LENGTH="30" NOTNULL="true" SEQUENCE="false" COMMENT="Meeting host user ID. Can be any user under this account. Cannot be updated after creation."/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -916,7 +916,7 @@ function xmldb_zoom_upgrade($oldversion) {
     }
 
     if ($oldversion < 2023111600) {
-        // Issue #326: Drop start_url from database
+        // Issue #326: Drop start_url from database.
 
         // Start zoom table modifications.
         $table = new xmldb_table('zoom');

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -915,5 +915,23 @@ function xmldb_zoom_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2023080202, 'zoom');
     }
 
+    if ($oldversion < 2023111600) {
+        // Issue #326: Drop start_url from database
+
+        // Start zoom table modifications.
+        $table = new xmldb_table('zoom');
+
+        // Define field status to be dropped from zoom.
+        $field = new xmldb_field('start_url');
+
+        // Conditionally launch drop field status.
+        if ($dbman->field_exists($table, $field)) {
+            $dbman->drop_field($table, $field);
+        }
+
+        // Zoom savepoint reached.
+        upgrade_mod_savepoint(true, 2023111600, 'zoom');
+    }
+
     return true;
 }

--- a/lib.php
+++ b/lib.php
@@ -277,7 +277,7 @@ function populate_zoom_from_response(stdClass $zoom, stdClass $response) {
 
     $newzoom = clone $zoom;
 
-    $samefields = ['start_url', 'join_url', 'created_at', 'timezone'];
+    $samefields = ['join_url', 'created_at', 'timezone'];
     foreach ($samefields as $field) {
         if (isset($response->$field)) {
             $newzoom->$field = $response->$field;

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_zoom';
-$plugin->version = 2023111000;
+$plugin->version = 2023111600;
 $plugin->release = 'v5.1.2';
 $plugin->requires = 2019052000;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Cleanup work to remove start_url from the database.

Testing: 
- [x] Should install with no issues as a new plugin.
- [x] Should upgrade with no issues as an existing plugin.
- [x] The functionality of the plugin should not be affected.

Fixes #326 