### PR TITLE
mod_form: bypass completion defaults issue in Moodle 4.3

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -49,7 +49,12 @@ class mod_zoom_mod_form extends moodleform_mod {
         global $PAGE, $USER, $OUTPUT;
 
         // We don't do anything custom with completion data, so avoid doing any unnecessary work.
-        if ($PAGE->pagetype === 'course-editbulkcompletion' || $PAGE->pagetype === 'course-editdefaultcompletion') {
+        $completionpagetypes = [
+            'course-defaultcompletion' => 'Edit completion default settings (Moodle >= 4.3)',
+            'course-editbulkcompletion' => 'Edit completion settings in bulk for a single course',
+            'course-editdefaultcompletion' => 'Edit completion default settings (Moodle < 4.3)',
+        ];
+        if (isset($completionpagetypes[$PAGE->pagetype])) {
             return;
         }
 


### PR DESCRIPTION
In Moodle 4.3, the URL for the completion defaults page was changed from `editdefaultcompletion` to `defaultcompletion`. This meant that our current, slightly evil, approach to not making a bunch of API calls on completion pages stopped working. This adds the new pagetype to the list and retains the old one for backward compatibility.

Fixes #552 
Supersedes #553

Thanks @opitz!