### PR TITLE
db: revert registration upgrade; fix tables that upgraded

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -934,10 +934,11 @@ function xmldb_zoom_upgrade($oldversion) {
     }
 
     if ($oldversion < 2024012500) {
+        // Version 5.1.0 incorrectly upgraded the zoom table's registration field. It should not be null and should default to 2.
         $table = new xmldb_table('zoom');
         $field = new xmldb_field('registration', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '2', 'option_auto_recording');
 
-        // Launch change of notnull for field registration.
+        // Launch change of nullability for field registration.
         $dbman->change_field_notnull($table, $field);
 
         // Launch change of default for field registration.

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -874,7 +874,7 @@ function xmldb_zoom_upgrade($oldversion) {
         $table = new xmldb_table('zoom');
 
         // Define and conditionally add field registration.
-        $field = new xmldb_field('registration', XMLDB_TYPE_INTEGER, '1', null, null, null, null, 'option_auto_recording');
+        $field = new xmldb_field('registration', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '2', 'option_auto_recording');
         if (!$dbman->field_exists($table, $field)) {
             $dbman->add_field($table, $field);
         }
@@ -931,6 +931,20 @@ function xmldb_zoom_upgrade($oldversion) {
 
         // Zoom savepoint reached.
         upgrade_mod_savepoint(true, 2023111600, 'zoom');
+    }
+
+    if ($oldversion < 2024012500) {
+        $table = new xmldb_table('zoom');
+        $field = new xmldb_field('registration', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '2', 'option_auto_recording');
+
+        // Launch change of notnull for field registration.
+        $dbman->change_field_notnull($table, $field);
+
+        // Launch change of default for field registration.
+        $dbman->change_field_default($table, $field);
+
+        // Zoom savepoint reached.
+        upgrade_mod_savepoint(true, 2024012500, 'zoom');
     }
 
     return true;

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_zoom';
-$plugin->version = 2023121400;
+$plugin->version = 2024012500;
 $plugin->release = 'v5.1.4';
 $plugin->requires = 2019052000;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
The registration field definition was unintentionally changed. Some users upgraded after that change and have the wrong database column settings. After upgrading again, those users will have the correct column settings.

Fixes #563 
Regression from #505 