### PR TITLE
upgrade: set null registration values to new default before alter

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -938,6 +938,9 @@ function xmldb_zoom_upgrade($oldversion) {
         $table = new xmldb_table('zoom');
         $field = new xmldb_field('registration', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '2', 'option_auto_recording');
 
+        // Set any null values to the new default: 2.
+        $DB->set_field_select('zoom', 'registration', '2', 'registration IS NULL');
+
         // Launch change of nullability for field registration.
         $dbman->change_field_notnull($table, $field);
 


### PR DESCRIPTION
Although the XMLDB Editor provides helpful PHP code to update fields, the underlying functions do not automatically make sure to set the NULL values to the new default value when switching the nullability of the field.

Here's a similar example from Moodle core: https://github.com/moodle/moodle/blame/3fc907e3d8646d53b744cbeb2820f5a060cc86ee/lib/db/upgrade.php#L816-L821

Fixes #573 