### PR TITLE
Make section headers unique; set initial expanded sections

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -179,7 +179,8 @@ class mod_zoom_mod_form extends moodleform_mod {
         $this->standard_intro_elements();
 
         // Adding the "schedule" fieldset, where all settings relating to date and time are shown.
-        $mform->addElement('header', 'general', get_string('schedule', 'mod_zoom'));
+        $mform->addElement('header', 'schedule', get_string('schedule', 'mod_zoom'));
+        $mform->setExpanded('schedule');
 
         // Add date/time. Validation in validation().
         $starttimeoptions = [
@@ -462,7 +463,8 @@ class mod_zoom_mod_form extends moodleform_mod {
         $mform->setType('roomsgroups', PARAM_RAW);
 
         // Adding the "security" fieldset, where all settings relating to securing and protecting the meeting are shown.
-        $mform->addElement('header', 'general', get_string('security', 'mod_zoom'));
+        $mform->addElement('header', 'security', get_string('security', 'mod_zoom'));
+        $mform->setExpanded('security');
 
         // Deals with password manager issues.
         if (isset($this->current->password)) {
@@ -600,7 +602,8 @@ class mod_zoom_mod_form extends moodleform_mod {
         $mform->addHelpButton('show_security', 'showsecurity', 'zoom');
 
         // Adding the "media" fieldset, where all settings relating to media streams in the meeting are shown.
-        $mform->addElement('header', 'general', get_string('media', 'mod_zoom'));
+        $mform->addElement('header', 'media', get_string('media', 'mod_zoom'));
+        $mform->setExpanded('media');
 
         // Add host/participants video options.
         $mform->addGroup([
@@ -692,7 +695,8 @@ class mod_zoom_mod_form extends moodleform_mod {
         $showalternativehosts = ($config->showalternativehosts != ZOOM_ALTERNATIVEHOSTS_DISABLE);
         if ($showschedulingprivilege || $showalternativehosts) {
             // Adding the "host" fieldset, where all settings relating to defining the meeting host are shown.
-            $mform->addElement('header', 'general', get_string('host', 'mod_zoom'));
+            $mform->addElement('header', 'host', get_string('host', 'mod_zoom'));
+            $mform->setExpanded('host');
 
             // Supplementary feature: Alternative hosts.
             // Only show if the admin did not disable this feature completely.
@@ -771,7 +775,7 @@ class mod_zoom_mod_form extends moodleform_mod {
 
         // Adding option for Recording Visiblity by default.
         if (!empty($config->viewrecordings)) {
-            $mform->addElement('header', 'general', get_string('recording', 'mod_zoom'));
+            $mform->addElement('header', 'recording', get_string('recording', 'mod_zoom'));
             $mform->addElement(
                 'advcheckbox',
                 'recordings_visible_default',


### PR DESCRIPTION
- Make activity settings page section header IDs unique
- Set Schedule, Breakout rooms, Security, Media, and Host sections to be expanded on page load.

Fixes #582 