### PR TITLE
Mobile app: Use module-info instead of module-description 

### DIFF
--- a/classes/output/mobile.php
+++ b/classes/output/mobile.php
@@ -78,6 +78,7 @@ class mobile {
             'option_audio' => $optionaudio,
             'cmid' => $cm->id,
             'courseid' => $args->courseid,
+            'canusemoduleinfo' => $args->appversioncode >= 44000,
         ];
 
         return [

--- a/templates/mobile_view_page_latest.mustache
+++ b/templates/mobile_view_page_latest.mustache
@@ -47,7 +47,13 @@
 }}
 {{=<% %>=}}
 <div>
-    <core-course-module-description description="<% zoom.intro %>" component="mod_zoom" componentId="<% cmid %>"></core-course-module-description>
+    <%#canusemoduleinfo%>
+        <core-course-module-info [module]="module" description="<% zoom.intro %>" component="mod_zoom" componentId="<% cmid %>" [courseId]="courseId">
+        </core-course-module-info>
+    <%/canusemoduleinfo%>
+    <%^canusemoduleinfo%>
+        <core-course-module-description description="<% zoom.intro %>" component="mod_zoom" componentId="<% cmid %>"></core-course-module-description>
+    <%/canusemoduleinfo%>
 
     <ion-list>
         <%#available%>


### PR DESCRIPTION
In this PR I'm removing the ionic3 code (the ionic5 app was released on 2021 so it should be safe to remove it).

I also removed the usage of core-course-module-description component for newer app versions, it is deprecated and will be removed in a future version of the app. It should have been removed already, but we kept it in the app because some plugins still use it.

