### PR TITLE
index: migrate from label to badge (Bootstrap 3 -> 4/5)

### DIFF
--- a/index.php
+++ b/index.php
@@ -156,7 +156,7 @@ foreach ($zooms as $z) {
         $oldtable->data[] = $row;
     } else {
         if ($inprogress) {
-            $label = html_writer::tag('span', $strmeetingstarted, ['class' => 'badge bg-info text-dark']);
+            $label = html_writer::tag('span', $strmeetingstarted, ['class' => 'badge bg-dark badge-dark bg-text-dark']);
             $row[2] = html_writer::tag('div', $label);
         } else {
             $row[2] = $displaytime;

--- a/index.php
+++ b/index.php
@@ -156,7 +156,7 @@ foreach ($zooms as $z) {
         $oldtable->data[] = $row;
     } else {
         if ($inprogress) {
-            $label = html_writer::tag('span', $strmeetingstarted, ['class' => 'label label-info zoom-info']);
+            $label = html_writer::tag('span', $strmeetingstarted, ['class' => 'badge bg-info text-dark']);
             $row[2] = html_writer::tag('div', $label);
         } else {
             $row[2] = $displaytime;

--- a/styles.css
+++ b/styles.css
@@ -1,9 +1,3 @@
-.zoom-info {
-    padding: 0.2em 0.6em 0.3em;
-    color: #fff;
-    border-radius: 0.25em;
-}
-
 #page-mod-zoom-view a .btn-primary .icon {
     color: white;
 }


### PR DESCRIPTION
`label` was in Bootstrap 3. Since Bootstrap 4 (theme boost; Moodle 3.2+), it's been `badge` and we don't need/want the custom CSS. The suggested change should work in Bootstrap 4.0 - 5.3+ (specifically Moodle 3.2 - 4.6+).

Fixes #601 