### PR TITLE
CI: Check Moodle 4.4 and PHP 8.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: '8.2'
+          - php: '8.3'
             moodle-branch: 'main'
+            database: 'mariadb'
+          - php: '8.3'
+            moodle-branch: 'MOODLE_404_STABLE'
             database: 'mariadb'
           - php: '8.2'
             moodle-branch: 'MOODLE_403_STABLE'
@@ -45,9 +48,6 @@ jobs:
             database: 'pgsql'
           - php: '7.4'
             moodle-branch: 'MOODLE_400_STABLE'
-            database: 'mariadb'
-          - php: '7.3'
-            moodle-branch: 'MOODLE_311_STABLE'
             database: 'pgsql'
           - php: '7.2'
             moodle-branch: 'MOODLE_39_STABLE'


### PR DESCRIPTION
Removes Moodle 3.11 and PHP 7.3 from the matrix, but we still test Moodle 3.9 (LTS), Moodle 4.0, PHP 7.2 and PHP 7.4, so it should be okay. 🤞 