### PR TITLE
webservice: use string 'null' when recording_type is null

### DIFF
--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -1070,7 +1070,7 @@ class webservice {
                     $recordinginfo->meetinguuid = $response->uuid;
                     $recordinginfo->url = $url;
                     $recordinginfo->filetype = $recording->file_type;
-                    $recordinginfo->recordingtype = $recording->recording_type;
+                    $recordinginfo->recordingtype = $recording->recording_type ?? 'null';
                     $recordinginfo->passcode = $response->password;
                     $recordinginfo->recordingstart = strtotime($recording->recording_start);
 
@@ -1120,7 +1120,7 @@ class webservice {
                         $recordinginfo->meetinguuid = $meeting->uuid;
                         $recordinginfo->url = $url;
                         $recordinginfo->filetype = $recording->file_type;
-                        $recordinginfo->recordingtype = $recording->recording_type;
+                        $recordinginfo->recordingtype = $recording->recording_type ?? 'null';
                         $recordinginfo->recordingstart = strtotime($recording->recording_start);
 
                         $recordings[$recording->id] = $recordinginfo;


### PR DESCRIPTION
This allows the data to be loaded in the database and not throw an exception. In theory, the value should never be null, but somehow it is for one of our users. In the rare case where this occurs, Moodle may show the string "null", but I'm not too worried about that being the worst-case.

Fixes #619

Marking this as draft until we have a better idea of what's going on. It shouldn't cause any problems, but it would be nice to know more.