### PR TITLE
passcode is encoded via "htmlspecialchars" function Closes #636

### DIFF
--- a/recordings.php
+++ b/recordings.php
@@ -132,7 +132,7 @@ if (empty($recordings)) {
         }
 
         // Output only one row per grouping.
-        $table->data[] = [$recordingdate, $recordinghtml, $recordingpasscode, $recordingshowhtml];
+        $table->data[] = [$recordingdate, $recordinghtml, htmlspecialchars($recordingpasscode), $recordingshowhtml];
     }
 }
 


### PR DESCRIPTION
This bugfix Closes #636 by encoding html special characters to display the correct passcode for recordings, in the unlucky case the passcode generated by zoom contains a sequence of characters that may be misinterpreted as html characters