### PR TITLE
Forward compatibility for PHPUnit tests

### DIFF
--- a/tests/advanced_passcode_test.php
+++ b/tests/advanced_passcode_test.php
@@ -36,16 +36,14 @@ final class advanced_passcode_test extends basic_testcase {
      */
     private $zoomdata;
 
-    // phpcs:disable moodle.NamingConventions.ValidFunctionName.LowercaseMethod
     /**
-     * Backward compatibility support for PHPUnit 8 (PHP 7.2 and 7.3).
+     * Check regular expressions. Compatibility support for PHPUnit.
      *
      * @param string $pattern Regular expression.
      * @param string $string String.
      * @param string $message Message.
      */
-    public static function assertMatchesRegularExpression($pattern, $string, $message = ''): void {
-        // phpcs:enable
+    public static function assert_regexp($pattern, $string, $message = ''): void {
         if (method_exists('basic_testcase', 'assertMatchesRegularExpression')) {
             parent::assertMatchesRegularExpression($pattern, $string, $message);
         } else {
@@ -126,8 +124,8 @@ final class advanced_passcode_test extends basic_testcase {
 
         $passcode = zoom_create_default_passcode($this->zoomdata);
         $this->assertEquals(strlen($passcode), 6);
-        $this->assertMatchesRegularExpression('/\d/', $passcode);
-        $this->assertMatchesRegularExpression('/[a-zA-Z]/', $passcode);
+        $this->assert_regexp('/\d/', $passcode);
+        $this->assert_regexp('/[a-zA-Z]/', $passcode);
     }
 
     /**
@@ -145,9 +143,9 @@ final class advanced_passcode_test extends basic_testcase {
 
         $passcode = zoom_create_default_passcode($this->zoomdata);
         $this->assertEquals(strlen($passcode), 6);
-        $this->assertMatchesRegularExpression('/\d/', $passcode);
-        $this->assertMatchesRegularExpression('/[A-Z]/', $passcode);
-        $this->assertMatchesRegularExpression('/[a-z]/', $passcode);
+        $this->assert_regexp('/\d/', $passcode);
+        $this->assert_regexp('/[A-Z]/', $passcode);
+        $this->assert_regexp('/[a-z]/', $passcode);
     }
 
     /**
@@ -165,8 +163,8 @@ final class advanced_passcode_test extends basic_testcase {
 
         $passcode = zoom_create_default_passcode($this->zoomdata);
         $this->assertEquals(strlen($passcode), 6);
-        $this->assertMatchesRegularExpression('/\d/', $passcode);
-        $this->assertMatchesRegularExpression('/[^a-zA-Z\d]/', $passcode);
+        $this->assert_regexp('/\d/', $passcode);
+        $this->assert_regexp('/[^a-zA-Z\d]/', $passcode);
     }
 
     /**
@@ -184,9 +182,9 @@ final class advanced_passcode_test extends basic_testcase {
 
         $passcode = zoom_create_default_passcode($this->zoomdata);
         $this->assertEquals(strlen($passcode), 7);
-        $this->assertMatchesRegularExpression('/\d/', $passcode);
-        $this->assertMatchesRegularExpression('/[a-zA-Z]/', $passcode);
-        $this->assertMatchesRegularExpression('/[^a-zA-Z\d]/', $passcode);
+        $this->assert_regexp('/\d/', $passcode);
+        $this->assert_regexp('/[a-zA-Z]/', $passcode);
+        $this->assert_regexp('/[^a-zA-Z\d]/', $passcode);
     }
 
     /**

--- a/view.php
+++ b/view.php
@@ -281,7 +281,6 @@ if ($zoom->show_schedule) {
         if ($nextoccurrence > 0) {
             $meetingtimetext->text = userdate($nextoccurrence);
         } else {
-
             $meetingtimetext->text = get_string('nooccurrenceleft', 'mod_zoom');
         }
     } else {


### PR DESCRIPTION
This fixes the Moodle main branch tests that are currently failing.

 - Better assertMatchesRegularExpression forward compatibility and maintains assertRegExp backward compatibility
 - Adds forward compatibility for Mock Builder's onlyMethods while maintaining setMethods backward compatibility
 - Small PHPCS cleanups