### PR TITLE
mod_form: revert hidden field string change

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -829,7 +829,7 @@ class mod_zoom_mod_form extends moodleform_mod {
         // Requires Moodle 3.8+. Hide field if the grade item is not graded.
         if (class_exists('\\core_grades\\component_gradeitems')) {
             $gradefieldname = \core_grades\component_gradeitems::get_field_name_for_itemnumber($component, $itemnumber, 'grade');
-            $mform->hideIf('grading_method', $gradefieldname['modgrade_type'], 'eq', 'none');
+            $mform->hideIf('grading_method', "{$gradefieldname}[modgrade_type]", 'eq', 'none');
         }
     }
 


### PR DESCRIPTION
`$gradefieldname` is a string, so while the code looked like an array index, it's actually a string concatenation which matches examples from Moodle core.

Reference: https://github.com/moodle/moodle/blob/688478cfa443945dbdc30fee45984585cc23eb0a/mod/forum/mod_form.php#L285

Thanks @bobopinna for mentioning this on 96998ad

Fixes #643 