### PR TITLE
Populate calendar with only items that were not deleted

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -512,7 +512,7 @@ function zoom_calendar_item_update(stdClass $zoom) {
     } else if (!empty($zoom->occurrences)) {
         foreach ($zoom->occurrences as $occurrence) {
             $uuid = $occurrence->occurrence_id;
-            if ($occurrence->status != "deleted") {
+            if ($occurrence->status !== 'deleted') {
                 $newevents[$uuid] = zoom_populate_calender_item($zoom, $occurrence);
             }
         }

--- a/lib.php
+++ b/lib.php
@@ -512,7 +512,9 @@ function zoom_calendar_item_update(stdClass $zoom) {
     } else if (!empty($zoom->occurrences)) {
         foreach ($zoom->occurrences as $occurrence) {
             $uuid = $occurrence->occurrence_id;
-            $newevents[$uuid] = zoom_populate_calender_item($zoom, $occurrence);
+            if ($occurrence->status != "deleted") {
+                $newevents[$uuid] = zoom_populate_calender_item($zoom, $occurrence);
+            }
         }
     }
 


### PR DESCRIPTION
- Updated zoom_calendar_item_update() to check if the occurrence has been "deleted"
- If occurrence status is "deleted", do not add to calendar

Fixes #641 