### PR TITLE
update_tracking_fields: Define $service variable

### DIFF
--- a/classes/task/update_tracking_fields.php
+++ b/classes/task/update_tracking_fields.php
@@ -52,7 +52,7 @@ class update_tracking_fields extends scheduled_task {
      */
     public function execute() {
         try {
-            zoom_webservice();
+            $service = zoom_webservice();
         } catch (moodle_exception $exception) {
             mtrace('Skipping task - ', $exception->getMessage());
             return;


### PR DESCRIPTION
All of the other tasks had $service, so the same code worked. This one didn't.

Fixes #647 