### PR TITLE
Update webservice.php generalized autocreate function

### DIFF
--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -388,7 +388,7 @@ class webservice {
      * @param string $action The account create action: create, autoCreate, custCreate or ssoCreate.
      * @param int $type The user type number.
      * @return bool Whether the user was succesfully created.
-     * @deprecated Has never been used by internal code.
+     * @example https://github.com/yedidiaklein/moodle-local_zoomsyncusers An external plugin that depends on mod_zoom uses this method.
      */
     public function autocreate_user($user, $action = 'autoCreate', $type = ZOOM_USER_TYPE_PRO) {
         // Classic: user:write:admin.

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -388,7 +388,7 @@ class webservice {
      * @param string $action The account create action: create, autoCreate, custCreate or ssoCreate.
      * @param int $type The user type number.
      * @return bool Whether the user was succesfully created.
-     * @example https://github.com/yedidiaklein/moodle-local_zoomsyncusers An external plugin that depends on mod_zoom uses this method.
+     * @see https://github.com/yedidiaklein/moodle-local_zoomsyncusers An external plugin that depends on mod_zoom uses this method.
      */
     public function autocreate_user($user, $action = 'autoCreate', $type = ZOOM_USER_TYPE_PRO) {
         // Classic: user:write:admin.

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -388,14 +388,14 @@ class webservice {
      * @return bool Whether the user was succesfully created.
      * @deprecated Has never been used by internal code.
      */
-    public function autocreate_user($user) {
+    public function autocreate_user($user, $action = 'autoCreate', $type = ZOOM_USER_TYPE_PRO) {
         // Classic: user:write:admin.
         // Granular: user:write:user:admin.
         $url = 'users';
-        $data = ['action' => 'autocreate'];
+        $data = ['action' => $action];
         $data['user_info'] = [
             'email' => zoom_get_api_identifier($user),
-            'type' => ZOOM_USER_TYPE_PRO,
+            'type' => $type,
             'first_name' => $user->firstname,
             'last_name' => $user->lastname,
             'password' => base64_encode(random_bytes(16)),

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -385,6 +385,8 @@ class webservice {
      * Autocreate a user on Zoom.
      *
      * @param stdClass $user The user to create.
+     * @param string $action The account create action: create, autoCreate, custCreate or ssoCreate.
+     * @param int $type The user type number.
      * @return bool Whether the user was succesfully created.
      * @deprecated Has never been used by internal code.
      */


### PR DESCRIPTION
I know that the autocreate function is deprecated, but I wrote a plugin for auto creating users here:
https://github.com/yedidiaklein/moodle-local_zoomsyncusers

I use the zoom API from your plugin and I depend on it.

The existing autocreate function is broken and should use action autoCreate and not autocreate.

While fixing it, I also generilized this function to work for create and autoCreate and also to choose if needed the user type.

For backward compatibility I gave default values to the new parameters.

It would be great if you accept this minor PR.

Thanks a lot (and also tnx for this great plugin, that is working very well and is very usefull !)