### PR TITLE
get_meeting_reports: Use correct granular scopes for Dashboard API

### DIFF
--- a/classes/task/get_meeting_reports.php
+++ b/classes/task/get_meeting_reports.php
@@ -145,8 +145,9 @@ class get_meeting_reports extends scheduled_task {
 
         $dashboardscopes = [
             'dashboard_meetings:read:admin',
-            'dashboard_meetings:read:list_meetings:admin',
-            'dashboard_meetings:read:list_webinars:admin',
+            'dashboard_webinars:read:admin',
+            'dashboard:read:list_meetings:admin',
+            'dashboard:read:list_webinars:admin',
         ];
 
         $reportscopes = [
@@ -417,12 +418,12 @@ class get_meeting_reports extends scheduled_task {
 
         $meetingscopes = [
             'dashboard_meetings:read:admin',
-            'dashboard_meetings:read:list_meetings:admin',
+            'dashboard:read:list_meetings:admin',
         ];
 
         $webinarscopes = [
             'dashboard_webinars:read:admin',
-            'dashboard_webinars:read:list_webinars:admin',
+            'dashboard:read:list_webinars:admin',
         ];
 
         $meetings = [];

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -990,15 +990,19 @@ class webservice {
 
         if ($this->has_scope($reportscopes)) {
             $apitype = 'report';
+            $data = [];
         } else if ($this->has_scope($dashboardscopes)) {
             $apitype = 'metrics';
+            $data = [
+                'type' => 'past',
+            ];
         } else {
             mtrace('Missing OAuth scopes required for reports.');
             return [];
         }
 
         $url = $apitype . '/' . $meetingtype . '/' . $meetinguuid . '/participants';
-        return $this->make_paginated_call($url, [], 'participants');
+        return $this->make_paginated_call($url, $data, 'participants');
     }
 
     /**


### PR DESCRIPTION
Fixes get_meeting_reports task granular scopes support.

I attempted to add granular scope support for this task in v5.2.1 via 8581cb28b56668295253df1424006baf3e8312ba, but it seems that it never worked for Server-to-Server OAuth because I used the wrong scope strings. :sweat:

Also, the Dashboard API defaults to "live" data, so we need to specify "type = past".