### PR TITLE
Fix upgrade.php update SQL

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1029,7 +1029,7 @@ function xmldb_zoom_upgrade($oldversion) {
         $sql = "UPDATE {tool_customlang} tc
                    SET stringid = :newstringid
                  WHERE tc.stringid = :oldstringid
-                   AND tc.componentid in (SELECT tcc.id 
+                   AND tc.componentid in (SELECT tcc.id
                                             FROM {tool_customlang_components} tcc
                                            WHERE tcc.name = :componentname)";
 

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1029,9 +1029,11 @@ function xmldb_zoom_upgrade($oldversion) {
         $sql = "UPDATE {tool_customlang} tc
                    SET stringid = :newstringid
                  WHERE tc.stringid = :oldstringid
-                   AND tc.componentid in (SELECT tcc.id
-                                            FROM {tool_customlang_components} tcc
-                                           WHERE tcc.name = :componentname)";
+                   AND tc.componentid IN (
+                           SELECT tcc.id
+                             FROM {tool_customlang_components} tcc
+                            WHERE tcc.name = :componentname
+                       )";
 
         $params = [
             'newstringid' => 'calendardescriptionurl',

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1027,10 +1027,11 @@ function xmldb_zoom_upgrade($oldversion) {
     if ($oldversion < 2025062600) {
         // Define the SQL query to fix the inconsistent casing in the customlang stringid.
         $sql = "UPDATE {tool_customlang} tc
-                  JOIN {tool_customlang_components} tcc ON tc.componentid = tcc.id
-                   SET tc.stringid = :newstringid
-                 WHERE tcc.name = :componentname
-                   AND tc.stringid = :oldstringid";
+                   SET stringid = :newstringid
+                 WHERE tc.stringid = :oldstringid
+                   AND tc.componentid in (SELECT tcc.id 
+                                            FROM {tool_customlang_components} tcc
+                                           WHERE tcc.name = :componentname)";
 
         $params = [
             'newstringid' => 'calendardescriptionurl',


### PR DESCRIPTION
Using a JOIN clause inside an UPDATE is not standard SQL and breaks updating the plugin using PostgreSQL. This PR refactors the query to make it compatible with all supported DBMSs