### PR TITLE
release: v5.4.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ### Releases ###
 
+#### v5.4.3 ####
+
+- Bugfix: Rename string to avoid flawed database upgrade step #668 (thanks @samwitzig)
+
 #### v5.4.2 ####
 
 - Bugfix: Fix SQL compatibility in upgrade step #664 (thanks @izendegi, @SimonThornett)

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_zoom';
-$plugin->version = 2025071000;
-$plugin->release = 'v5.4.2';
+$plugin->version = 2025072100;
+$plugin->release = 'v5.4.3';
 $plugin->requires = 2019052000;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->cron = 0;


### PR DESCRIPTION
Supersedes v5.4.1 and v5.4.2, solving the stringid case-insensitivity issue by using a different stringid altogether. The lesson learned was "Custom SQL with differently configured databases is something to avoid".