### PR TITLE
SECURITY: Hardened shell command execution in get_meeting_report.php

### DIFF
--- a/console/get_meeting_report.php
+++ b/console/get_meeting_report.php
@@ -30,8 +30,8 @@ error_reporting(E_ALL);
 ini_set('display_errors', '1');
 
 $courseid = required_param('courseid', PARAM_INT);
-$startdate = optional_param('start', date('Y-m-d', strtotime('-3 days')), PARAM_ALPHANUMEXT);
-$enddate = optional_param('end', date('Y-m-d'), PARAM_ALPHANUMEXT);
+$startdate = escapeshellarg(optional_param('start', date('Y-m-d', strtotime('-3 days')), PARAM_ALPHANUMEXT));
+$enddate = escapeshellarg(optional_param('end', date('Y-m-d'), PARAM_ALPHANUMEXT));
 
 $course = $DB->get_record('course', ['id' => $courseid], '*', MUST_EXIST);
 


### PR DESCRIPTION
- Used escapeshellarg() for all string parameters passed to CLI script.
- Ensured only sanitized parameters are passed to the shell command.
- Prevented potential command injection.