### PR TITLE
tests: add generator for Behat tests

### DIFF
--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -314,7 +314,7 @@ class webservice {
                         if ($header['x-ratelimit-remaining'] == 0 && !empty($retryafter)) {
                             set_config('retry-after', $retryafter, 'zoom');
                             throw new api_limit_exception($response->message, $response->code, $retryafter);
-                        } else if (!(defined('PHPUNIT_TEST') && PHPUNIT_TEST)) {
+                        } else if (!(defined('PHPUNIT_TEST' || 'BEHAT_TEST') && PHPUNIT_TEST || BEHAT_TEST)) {
                             // When running CLI we might want to know how many calls remaining.
                             debugging('x-ratelimit-remaining = ' . $header['x-ratelimit-remaining']);
                         }
@@ -322,7 +322,7 @@ class webservice {
 
                     debugging('Received 429 response, sleeping ' . strval($timediff) .
                             ' seconds until next retry. Current retry: ' . $this->makecallretries);
-                    if ($timediff > 0 && !(defined('PHPUNIT_TEST') && PHPUNIT_TEST)) {
+                    if ($timediff > 0 && !(defined('PHPUNIT_TEST' || 'BEHAT_TEST') && PHPUNIT_TEST || BEHAT_TEST)) {
                         sleep($timediff);
                     }
                     return $this->make_call($path, $data, $method);

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -314,7 +314,7 @@ class webservice {
                         if ($header['x-ratelimit-remaining'] == 0 && !empty($retryafter)) {
                             set_config('retry-after', $retryafter, 'zoom');
                             throw new api_limit_exception($response->message, $response->code, $retryafter);
-                        } else if (!(defined('PHPUNIT_TEST' || 'BEHAT_TEST') && PHPUNIT_TEST || BEHAT_TEST)) {
+                        } else if (!((defined('PHPUNIT_TEST') && PHPUNIT_TEST) || (defined('BEHAT_TEST') && BEHAT_TEST))) {
                             // When running CLI we might want to know how many calls remaining.
                             debugging('x-ratelimit-remaining = ' . $header['x-ratelimit-remaining']);
                         }
@@ -322,7 +322,7 @@ class webservice {
 
                     debugging('Received 429 response, sleeping ' . strval($timediff) .
                             ' seconds until next retry. Current retry: ' . $this->makecallretries);
-                    if ($timediff > 0 && !(defined('PHPUNIT_TEST' || 'BEHAT_TEST') && PHPUNIT_TEST || BEHAT_TEST)) {
+                    if ($timediff > 0 && !((defined('PHPUNIT_TEST') && PHPUNIT_TEST) || (defined('BEHAT_TEST') && BEHAT_TEST))) {
                         sleep($timediff);
                     }
                     return $this->make_call($path, $data, $method);

--- a/lib.php
+++ b/lib.php
@@ -71,7 +71,7 @@ function zoom_add_instance(stdClass $zoom, ?mod_zoom_mod_form $mform = null) {
     global $CFG, $DB;
     require_once($CFG->dirroot . '/mod/zoom/locallib.php');
 
-    if (defined('PHPUNIT_TEST') && PHPUNIT_TEST) {
+    if (defined('PHPUNIT_TEST' || 'BEHAT_TEST') && PHPUNIT_TEST || BEHAT_TEST) {
         $zoom->id = $DB->insert_record('zoom', $zoom);
         zoom_grade_item_update($zoom);
         zoom_calendar_item_update($zoom);

--- a/lib.php
+++ b/lib.php
@@ -71,7 +71,7 @@ function zoom_add_instance(stdClass $zoom, ?mod_zoom_mod_form $mform = null) {
     global $CFG, $DB;
     require_once($CFG->dirroot . '/mod/zoom/locallib.php');
 
-    if (defined('PHPUNIT_TEST' || 'BEHAT_TEST') && PHPUNIT_TEST || BEHAT_TEST) {
+    if ((defined('PHPUNIT_TEST') && PHPUNIT_TEST) || (defined('BEHAT_TEST') && BEHAT_TEST)) {
         $zoom->id = $DB->insert_record('zoom', $zoom);
         zoom_grade_item_update($zoom);
         zoom_calendar_item_update($zoom);

--- a/tests/behat/behat_mod_zoom.php
+++ b/tests/behat/behat_mod_zoom.php
@@ -1,0 +1,96 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+require_once(__DIR__ . '/../../../../lib/behat/behat_base.php');
+use Behat\Behat\Context\Context;
+
+/**
+ * Behat steps for mod_zoom.
+ *
+ * @package mod_zoom
+ * @copyright 2020 UC Regents
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class behat_mod_zoom extends behat_base implements Context {
+    /**
+     * Convert page names to URLs for steps like 'When I am on the "[page name]" page'.
+     *
+     * Recognised page names are:
+     * | None so far!      |                                                              |
+     *
+     * @param string $page name of the page, with the component name removed e.g. 'Admin notification'.
+     * @return moodle_url the corresponding URL.
+     * @throws Exception with a meaningful error message if the specified page cannot be found.
+     */
+    protected function resolve_page_url(string $page): moodle_url {
+        switch (strtolower($page)) {
+            default:
+                throw new Exception("Unrecognized page type '{$page}'.");
+        }
+    }
+
+    /**
+     * Convert page names to URLs for steps like 'When I am on the "[identifier]" "[page type]" page'.
+     *
+     * Recognised page names are:
+     * | pagetype   | name meaning       | description                    |
+     * | View       | Zoom meeting name  | The Zoom meeting activity page |
+     *
+     * @param string $page identifies which type of page this is, e.g. 'mod_zoom > View'.
+     * @param string $identifier identifies the particular page, e.g. 'Test Meeting'.
+     * @return moodle_url the corresponding URL.
+     * @throws Exception with a meaningful error message if the specified page cannot be found.
+     */
+    protected function resolve_page_instance_url(string $type, string $identifier): moodle_url {
+        global $DB;
+
+        switch (strtolower($type)) {
+            case 'view':
+                return new moodle_url('/mod/zoom/view.php', [
+                    'id' => $this->get_cm_by_meeting_name($identifier)->id,
+                ]);
+            case 'edit':
+                return new moodle_url('/course/modedit.php', [
+                    'update' => $this->get_cm_by_meeting_name($identifier)->id,
+                    'return' => 0,
+                ]);
+            default:
+                throw new Exception('Unrecognized zoom page type: ' . $type);
+        }
+    }
+
+    /**
+     * Get a Zoom meeting by name.
+     *
+     * @param string $name Zoom meeting name.
+     * @return stdClass the corresponding DB row.
+     */
+    protected function get_meeting_by_name(string $name): stdClass {
+        global $DB;
+        return $DB->get_record('zoom', ['name' => $name]);
+    }
+
+    /**
+     * Get a Zoom meeting cmid from the meeting name.
+     *
+     * @param string $name Zoom meeting name.
+     * @return stdClass cm from get_coursemodule_from_instance.
+     */
+    protected function get_cm_by_meeting_name(string $name): stdClass {
+        $meeting = $this->get_meeting_by_name($name);
+        return get_coursemodule_from_instance('zoom', $meeting->id, $meeting->course);
+    }
+}

--- a/tests/behat/behat_mod_zoom.php
+++ b/tests/behat/behat_mod_zoom.php
@@ -21,7 +21,7 @@ use Behat\Behat\Context\Context;
  * Behat steps for mod_zoom.
  *
  * @package mod_zoom
- * @copyright 2020 UC Regents
+ * @copyright 2025 Alan McCoy
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class behat_mod_zoom extends behat_base implements Context {

--- a/tests/behat/behat_mod_zoom.php
+++ b/tests/behat/behat_mod_zoom.php
@@ -49,7 +49,7 @@ class behat_mod_zoom extends behat_base implements Context {
      * | pagetype   | name meaning       | description                    |
      * | View       | Zoom meeting name  | The Zoom meeting activity page |
      *
-     * @param string $page identifies which type of page this is, e.g. 'mod_zoom > View'.
+     * @param string $type identifies which type of page this is, e.g. 'mod_zoom > View'.
      * @param string $identifier identifies the particular page, e.g. 'Test Meeting'.
      * @return moodle_url the corresponding URL.
      * @throws Exception with a meaningful error message if the specified page cannot be found.

--- a/tests/behat/view_meeting.feature
+++ b/tests/behat/view_meeting.feature
@@ -1,0 +1,28 @@
+@mod @mod_zoom
+Feature: View a meeting
+
+  Background:
+    Given the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Terry1    | Teacher1 | teacher1@example.com |
+      | student1 | Sam1      | Student1 | student1@example.com |
+    And the following "courses" exist:
+      | fullname | shortname | format |
+      | Course 1 | C1        | topics |
+    And the following "course enrolments" exist:
+      | user     | course | role           |
+      | teacher1 | C1     | editingteacher |
+      | student1 | C1     | student        |
+    And the following "activity" exists:
+      | activity | zoom                     |
+      | course   | C1                       |
+      | idnumber | 00001                    |
+      | name     | Meeting 1        |
+      | intro    | Test meeting description |
+      | section  | 1                        |
+      | grade    | 100                      |
+
+  @javascript
+  Scenario: As a student, I should be able to view a Zoom meeting's details
+    When I am on the "Meeting 1" "mod_zoom > View" page logged in as "student1"
+    Then I should see "Start Time"

--- a/tests/generator/behat_mod_zoom_generator.php
+++ b/tests/generator/behat_mod_zoom_generator.php
@@ -1,0 +1,81 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Behat data generator for mod_zoom
+ *
+ * @package mod_zoom
+ * @copyright 2020 UC Regents
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class behat_mod_zoom_generator extends behat_generator_base {
+    /**
+     * Get a list of entities that can be created.
+     *
+     * @return array
+     */
+    protected function get_creatable_entities(): array {
+        return [
+            'meetings' => [
+                'singular' => 'meeting',
+                'datagenerator' => 'meeting',
+                'required' => ['name'],
+            ],
+        ];
+    }
+
+
+    /**
+     * Look up the id of a Zoom meeting from its name.
+     *
+     * @param string $zoommeetingname the Zoom activity name, for example 'Test meeting'.
+     * @return int corresponding id.
+     * @throws Exception
+     */
+    protected function get_zoom_id(string $zoomname): int {
+        global $DB;
+
+        if (!$id = $DB->get_field('zoom', 'id', ['name' => $zoomname])) {
+            throw new Exception('There is no Zoom activity with name "' . $zoomname . '" does not exist');
+        }
+        return $id;
+    }
+
+    /**
+     * Get the activity id from its name
+     *
+     * @param string $activityname
+     * @return int
+     * @throws Exception
+     */
+    protected function get_activity_id(string $activityname): int {
+        global $DB;
+
+        $sql = <<<EOF
+            SELECT cm.instance
+              FROM {course_modules} cm
+        INNER JOIN {modules} m ON m.id = cm.module
+        INNER JOIN {zoom} z ON z.id = cm.instance
+             WHERE cm.idnumber = :idnumber or z.name = :name
+EOF;
+        $id = $DB->get_field_sql($sql, ['idnumber' => $activityname, 'name' => $activityname]);
+        if (empty($id)) {
+            throw new Exception("There is no Zoom meeting with name '{$activityname}' does not exist");
+        }
+
+        return $id;
+    }
+}

--- a/tests/generator/behat_mod_zoom_generator.php
+++ b/tests/generator/behat_mod_zoom_generator.php
@@ -69,7 +69,7 @@ class behat_mod_zoom_generator extends behat_generator_base {
               FROM {course_modules} cm
         INNER JOIN {modules} m ON m.id = cm.module
         INNER JOIN {zoom} z ON z.id = cm.instance
-             WHERE cm.idnumber = :idnumber or z.name = :name
+             WHERE cm.idnumber = :idnumber OR z.name = :name
 EOF;
         $id = $DB->get_field_sql($sql, ['idnumber' => $activityname, 'name' => $activityname]);
         if (empty($id)) {

--- a/tests/generator/behat_mod_zoom_generator.php
+++ b/tests/generator/behat_mod_zoom_generator.php
@@ -67,8 +67,8 @@ class behat_mod_zoom_generator extends behat_generator_base {
         $sql = <<<EOF
             SELECT cm.instance
               FROM {course_modules} cm
-        INNER JOIN {modules} m ON m.id = cm.module
-        INNER JOIN {zoom} z ON z.id = cm.instance
+              JOIN {modules} m ON m.id = cm.module
+              JOIN {zoom} z ON z.id = cm.instance
              WHERE cm.idnumber = :idnumber OR z.name = :name
 EOF;
         $id = $DB->get_field_sql($sql, ['idnumber' => $activityname, 'name' => $activityname]);

--- a/tests/generator/behat_mod_zoom_generator.php
+++ b/tests/generator/behat_mod_zoom_generator.php
@@ -41,7 +41,7 @@ class behat_mod_zoom_generator extends behat_generator_base {
     /**
      * Look up the id of a Zoom meeting from its name.
      *
-     * @param string $zoommeetingname the Zoom activity name, for example 'Test meeting'.
+     * @param string $zoomname The Zoom activity name, for example 'Test meeting'.
      * @return int corresponding id.
      * @throws Exception
      */

--- a/tests/generator/behat_mod_zoom_generator.php
+++ b/tests/generator/behat_mod_zoom_generator.php
@@ -18,7 +18,7 @@
  * Behat data generator for mod_zoom
  *
  * @package mod_zoom
- * @copyright 2020 UC Regents
+ * @copyright 2025 Alan McCoy
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class behat_mod_zoom_generator extends behat_generator_base {

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -45,7 +45,7 @@ class mod_zoom_generator extends testing_module_generator {
             'meetingcode' => '',
             'webinar' => 0,
             'option_host_video' => 0,
-            'option_audio' => 0,
+            'option_audio' => ZOOM_AUDIO_BOTH,
             'recurring' => 0,
             'option_participants_video' => 0,
             'option_jbh' => 0,


### PR DESCRIPTION
- The edits to `classes/webservice.php` and `lib.php` serve to allow Behat tests to circumvent the Zoom webservice check in the same way PHPUnit tests do.
- The file `tests/generator/behat_mod_zoom_generator.php` isn't used in the basic Behat test included (`tests/behat/view_meeting.feature`) but it's included in the event future tests may require it (probably with some additional edits).
- Behat tests for Zoom activity edit page interaction are currently failing, so some additional work to be able to include those related scenarios is needed.