### PR TITLE
recording: fix duplicate string syntax

### DIFF
--- a/loadrecording.php
+++ b/loadrecording.php
@@ -30,7 +30,7 @@ require_once(__DIR__ . '/locallib.php');
 $recordingid = required_param('recordingid', PARAM_INT);
 
 if (!get_config('zoom', 'viewrecordings')) {
-    throw new moodle_exception('recordingnotvisible', 'mod_zoom', get_string('recordingnotvisible', 'zoom'));
+    throw new moodle_exception('recordingnotvisible', 'mod_zoom');
 }
 
 [$course, $cm, $zoom] = zoom_get_instance_setup();
@@ -49,7 +49,7 @@ $params = [
 ];
 $rec = $DB->get_record('zoom_meeting_recordings', $params);
 if (empty($rec)) {
-    throw new moodle_exception('recordingnotfound', 'mod_zoom', '', get_string('recordingnotfound', 'zoom'));
+    throw new moodle_exception('recordingnotfound', 'mod_zoom');
 }
 
 $params = ['recordingsid' => $rec->id, 'userid' => $USER->id];

--- a/recordings.php
+++ b/recordings.php
@@ -32,7 +32,7 @@ require_once(__DIR__ . '/locallib.php');
 require_login($course, true, $cm);
 
 if (!get_config('zoom', 'viewrecordings')) {
-    throw new moodle_exception('recordingnotvisible', 'mod_zoom', get_string('recordingnotvisible', 'zoom'));
+    throw new moodle_exception('recordingnotvisible', 'mod_zoom');
 }
 
 $context = context_module::instance($cm->id);

--- a/showrecording.php
+++ b/showrecording.php
@@ -32,7 +32,7 @@ $recordingstart = required_param('recordingstart', PARAM_INT);
 $showrecording = required_param('showrecording', PARAM_INT);
 
 if (!get_config('zoom', 'viewrecordings')) {
-    throw new moodle_exception('recordingnotvisible', 'mod_zoom', get_string('recordingnotvisible', 'zoom'));
+    throw new moodle_exception('recordingnotvisible', 'mod_zoom');
 }
 
 [$course, $cm, $zoom] = zoom_get_instance_setup();
@@ -58,7 +58,7 @@ $recordings = $DB->get_records(
     ]
 );
 if (empty($recordings)) {
-    throw new moodle_exception('recordingnotfound', 'mod_zoom', '', get_string('recordingnotfound', 'zoom'));
+    throw new moodle_exception('recordingnotfound', 'mod_zoom');
 }
 
 $now = time();


### PR DESCRIPTION
The `get_string()` call is already performed as part of the `moodle_exception` process, so the extra code was halfway between syntax error and redundant code.