### PR TITLE
lib: call grade reset when zoom reset userdata is checked

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -873,6 +873,9 @@ function zoom_reset_userdata($data) {
             'item' => get_string('meetingrecordingviewsdeleted', 'zoom'),
             'error' => false,
         ];
+
+        // The Zoom reset checkbox resets all user grades, always.
+        zoom_reset_gradebook($data->courseid);
     }
 
     return $status;

--- a/lib.php
+++ b/lib.php
@@ -876,6 +876,11 @@ function zoom_reset_userdata($data) {
 
         // The Zoom reset checkbox resets all user grades, always.
         zoom_reset_gradebook($data->courseid);
+        $status[] = [
+            'component' => $componentstr,
+            'item' => get_string('grades'),
+            'error' => false,
+        ];
     }
 
     return $status;


### PR DESCRIPTION
There are two options in the course reset that we need to support. 

The first is when the grade reset for the course is checked.  This should be handled already with our existing `zoom_reset_gradebook` function.

The second is when zoom specific reset option is checked which reads, _"Delete all user grades, recording user view data, and meeting participant user data."_ In this case, we were not reseting grades.  So this pull requests adds `zoom_reset_gradebook` to that function.  Since it's a nuclear checkbox that does all, we don't need to check for `$data->reset_gradebook_grades`

Fixes #693 