### PR TITLE
view: prioritize Moodle capabilities over assumed access of hosts

### DIFF
--- a/lang/en/zoom.php
+++ b/lang/en/zoom.php
@@ -416,7 +416,6 @@ $string['showsecurity'] = 'Show Security section';
 $string['showsecurity_help'] = 'Enabling this option will show the Security section on the meeting activity page.';
 $string['showsecurityonview'] = 'Show Security section on meeting page';
 $string['start'] = 'Start';
-$string['start_meeting'] = 'Start Meeting';
 $string['start_time'] = 'When';
 $string['starthostjoins'] = 'Start video when host joins';
 $string['startpartjoins'] = 'Start video when participant joins';

--- a/view.php
+++ b/view.php
@@ -58,9 +58,7 @@ $PAGE->requires->js_call_amd("mod_zoom/toggle_text", 'init');
 $zoomuserid = zoom_get_user_id(false);
 
 // Check if this user is the (real) host.
-if (!is_role_switched($course->id)) {
-    $userisrealhost = ($zoomuserid === $zoom->host_id);
-}
+$userisrealhost = ($zoomuserid === $zoom->host_id);
 
 // Get the alternative hosts of the meeting.
 $alternativehosts = zoom_get_alternative_host_array_from_string($zoom->alternative_hosts);
@@ -97,7 +95,6 @@ $isrecurringnotime = ($zoom->recurring && $zoom->recurrence_type == ZOOM_RECURRI
 
 $stryes = get_string('yes');
 $strno = get_string('no');
-$strstart = get_string('start_meeting', 'mod_zoom');
 $strjoin = get_string('join_meeting', 'mod_zoom');
 $strregister = get_string('register', 'mod_zoom');
 $strtime = get_string('meeting_time', 'mod_zoom');
@@ -151,7 +148,7 @@ if ($zoom->intro && $CFG->branch < '400') {
 // Only show if the admin did not disable this feature completely.
 if (!$showrecreate && $config->showcapacitywarning == true) {
     // Only show if the user viewing this is the host.
-    if ($userishost && $iszoommanager) {
+    if ($iszoommanager) {
         // Get meeting capacity.
         $meetingcapacity = zoom_get_meeting_capacity($zoom->host_id, $zoom->webinar);
 
@@ -204,8 +201,11 @@ if (!$showrecreate && $config->showcapacitywarning == true) {
 
 // Show join meeting button or unavailability note.
 if (!$showrecreate) {
-    // If registration is required, check the registration.
-    if (!$userishost && $zoom->registration != ZOOM_REGISTRATION_OFF) {
+    if ($userishost) {
+        // Hosts are pre-registered.
+        $userisregistered = true;
+    } else if ($zoom->registration != ZOOM_REGISTRATION_OFF) {
+        // If registration is required, check the registration.
         $userisregistered = zoom_is_user_registered_for_meeting($USER->email, $zoom->meeting_id, $zoom->webinar);
 
         // Unregistered users are allowed to register.
@@ -216,17 +216,14 @@ if (!$showrecreate) {
 
     if ($available) {
         // Show join meeting button.
-        if ($userishost && $iszoommanager) {
-            $buttonhtml = html_writer::tag('button', $strstart, ['type' => 'submit', 'class' => 'btn btn-success']);
-        } else {
-            $btntext = $strjoin;
-            // If user is not already registered, use register text.
-            if ($zoom->registration != ZOOM_REGISTRATION_OFF && !$userisregistered) {
-                $btntext = $strregister;
-            }
+        $btntext = $strjoin;
 
-            $buttonhtml = html_writer::tag('button', $btntext, ['type' => 'submit', 'class' => 'btn btn-primary']);
+        // If user is not already registered, use register text.
+        if ($zoom->registration != ZOOM_REGISTRATION_OFF && !$userisregistered) {
+            $btntext = $strregister;
         }
+
+        $buttonhtml = html_writer::tag('button', $btntext, ['type' => 'submit', 'class' => 'btn btn-primary']);
 
         $aurl = new moodle_url('/mod/zoom/loadmeeting.php', ['id' => $cm->id]);
         $buttonhtml .= html_writer::input_hidden_params($aurl);
@@ -449,7 +446,7 @@ if ($zoom->show_security) {
     // Get passcode information.
     $haspassword = (isset($zoom->password) && $zoom->password !== '');
     $strhaspass = ($haspassword) ? $stryes : $strno;
-    $canviewjoinurl = (($userishost && $iszoommanager) || has_capability('mod/zoom:viewjoinurl', $context));
+    $canviewjoinurl = has_capability('mod/zoom:viewjoinurl', $context);
 
     // Show passcode status.
     $rowhaspass = new html_table_row();
@@ -583,7 +580,7 @@ if ($zoom->show_media) {
     if (
         !$showrecreate
         && ($zoom->option_audio === ZOOM_AUDIO_BOTH || $zoom->option_audio === ZOOM_AUDIO_TELEPHONY)
-        && (($userishost && $iszoommanager) || has_capability('mod/zoom:viewdialin', $context))
+        && has_capability('mod/zoom:viewdialin', $context)
     ) {
         // Get meeting invitation from Zoom.
         $meetinginvite = zoom_webservice()->get_meeting_invitation($zoom)->get_display_string($cm->id);


### PR DESCRIPTION
I didn't know how to communicate my ideas clearly in #697. This pull request builds on that pull request, prioritizing Moodle capabilities over access assumptions for hosts and Zoom activity managers.

In summary:

- We don't need to check for a role switch, because the user is still the user.
- Meeting capacity warnings should be shown to all users who can edit the activity.
- If the user is a host (real or alternative), then they are already registered for the activity. A role switch does not and should not change their view of that.
- (optional) The "Start Meeting" message is too confusing. Hosts and non-hosts are both going to join the meeting. If join before host is enable, then the hosts aren't technically starting the meeting anyway, so simplify the logic and reduce the confusion.
- As we already have dedicated capabilities for `viewjoinurl` and `viewdialin`, it is wrong for us to override the Moodle administrator's choice of whether or not the user (based on their role) should have access to view that information. The Moodle administrator can decide whether `viewjoinurl` and `viewdialin` are granted to roles that can edit Zoom activities or not and we should respect/reflect that choice.

Net effect for complicated host variables:

- `$userishost` is now only used to determine if the user is pre-registered
- `$userisrealhost` does not emit PHP Notice when role switched