### PR TITLE
webservice: remove debug message from admin settings page

### DIFF
--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -1242,7 +1242,9 @@ class webservice {
             $this->get_access_token();
         }
 
-        mtrace('checking has_scope(' . implode(' || ', $scopes) . ')');
+        if (CLI_SCRIPT) {
+            mtrace('checking has_scope(' . implode(' || ', $scopes) . ')');
+        }
 
         $matchingscopes = \array_intersect($scopes, $this->scopes);
         return !empty($matchingscopes);


### PR DESCRIPTION
Fixes #691 

The CLI_SCRIPT check remains true when running a task manually through the admin interface. You can see the has_scope check in the output.

Example below: the Get meeting report from Zoom task (\mod_zoom\task\get_meeting_reports) calls the has_scope check. I ran it in my test instance and here is part of the output.
<img width="1111" height="230" alt="image" src="https://github.com/user-attachments/assets/76d5633f-d241-4f6d-b518-20b2753379c9" />
