### PR TITLE
ical Notifications: Fix users to notify

### DIFF
--- a/classes/task/send_ical_notifications.php
+++ b/classes/task/send_ical_notifications.php
@@ -272,7 +272,7 @@ class send_ical_notifications extends scheduled_task {
      */
     private function get_users_to_notify(int $zoomid, int $courseid) {
         $cminfo = get_fast_modinfo($courseid)->instances['zoom'][$zoomid];
-        $users = get_users_by_capability($cminfo->context, 'mod/zoom:view');
+        $users = get_enrolled_users($cminfo->context, 'mod/zoom:view', 0, 'u.*', null, 0, 0, true);
 
         if (empty($users)) {
             return [];


### PR DESCRIPTION
Send ical notifications task: Fix users to notify.

Previously we made use of the 'get_users_by_capability', but we noticed that is not sufficient. 

We copied a course that contained a zoom activity scheduled for a future time.
The copied course doesn't contain any user enrolments (we selected that option).
But then the ical notifications would still be sent to users with high-level capabilities in the copied course's zoom activity. This is incorrect since it should only be sent to users enrolled within the course.