### PR TITLE
webservice: get_recording_url_list error handling

### DIFF
--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -1135,9 +1135,22 @@ class webservice {
         // Classic: recording:read:admin.
         // Granular: cloud_recording:read:list_recording_files:admin.
         $url = 'meetings/' . $this->encode_uuid($meetingid) . '/recordings';
-        $response = $this->make_call($url);
 
-        if (!empty($response->recording_files)) {
+        try {
+            $response = $this->make_call($url);
+        } catch (not_found_exception $e) {
+            // If the meeting was not found (1001) or there are no recordings (3301), return an empty array.
+            return [];
+        }
+
+        if (empty($response->recording_files)) {
+            $recordingcount = (int) $response->recording_count;
+            $audiocount = count($response->participant_audio_files);
+            if ($recordingcount !== $audiocount) {
+                // If there are no recording files and the recording count does not match, throw an exception.
+                throw new bad_request_exception("recording_count: $recordingcount != participant_audio_files: $audiocount", 400);
+            }
+        } else {
             foreach ($response->recording_files as $recording) {
                 $url = $recording->play_url ?? $recording->download_url ?? null;
                 if (!empty($url) && isset($allowedrecordingtypes[$recording->file_type])) {

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -1144,6 +1144,10 @@ class webservice {
         }
 
         if (empty($response->recording_files)) {
+            if (!isset($response->recording_count)) {
+                throw new bad_request_exception('recording_count: undefined', 400);
+            }
+
             $recordingcount = (int) $response->recording_count;
             $audiocount = count($response->participant_audio_files);
             if ($recordingcount !== $audiocount) {


### PR DESCRIPTION
We need get_recording_url_list() to return an array of recordings. So when the API gives us an error message that means "there are no recordings", then we need to return an empty array (so that it matches). If the API gives us an error message that means "there was a problem when we tried to find the recordings", then we don't want to pretend that we know how many recordings there are (so we allow other exception types to bubble up). Finally, if there was no API error message, then we should have an API response that we can use. However, the code is written to assume that we know how the API response is structured. If the code is in the structure that we expect, then use it. Otherwise, we should throw our own "unexpected response structure" error message to avoid returning incorrect information.

Fixes #684 
Fixes #704 