### PR TITLE
behat: configure during step; javascript is unnecessary

### DIFF
--- a/tests/behat/view_meeting.feature
+++ b/tests/behat/view_meeting.feature
@@ -2,7 +2,12 @@
 Feature: View a meeting
 
   Background:
-    Given the following "users" exist:
+    Given the following config values are set as admin:
+      | config       | value | plugin | encrypted |
+      | accountid    | test  | zoom   |           |
+      | clientid     | test  | zoom   |           |
+      | clientsecret | test  | zoom   |           |
+    And the following "users" exist:
       | username | firstname | lastname | email                |
       | teacher1 | Terry1    | Teacher1 | teacher1@example.com |
       | student1 | Sam1      | Student1 | student1@example.com |
@@ -22,7 +27,6 @@ Feature: View a meeting
       | section  | 1                        |
       | grade    | 100                      |
 
-  @javascript
   Scenario: As a student, I should be able to view a Zoom meeting's details
     When I am on the "Meeting 1" "mod_zoom > View" page logged in as "student1"
     Then I should see "Start Time"

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -32,10 +32,6 @@ class mod_zoom_generator extends testing_module_generator {
         global $CFG;
         require_once($CFG->dirroot . '/mod/zoom/locallib.php');
 
-        set_config('clientid', 'test', 'zoom');
-        set_config('clientsecret', 'test', 'zoom');
-        set_config('accountid', 'test', 'zoom');
-
         // Mock Zoom data for testing.
         $defaultzoomsettings = [
             'grade' => 0,


### PR DESCRIPTION
At this time, the view_meeting Behat test does not require the `@javascript` tag and should therefore not include it. The generator class was setting configuration, which prevented values set in the Behat feature file from being used.

Fun side note: the mod_zoom plugin is saving all of its configuration settings using the outdated naming convention (without the mod_ prefix). Moodle's [developer documentation](https://moodledev.io/docs/5.2/apis/subsystems/admin) has included a note about this since May 2015:

> new activity modules should use 'mod_mymodule/setting' instead of 'mymodule/setting'

Looks like it was primarily using the modern frankenstyle name until #214. Meanwhile, look how naive I was in early 2021: https://github.com/ncstate-delta/moodle-mod_zoom/issues/180#issuecomment-777835649 😅 