### PR TITLE
settings: cleanup

### DIFF
--- a/backup/moodle2/backup_zoom_activity_task.class.php
+++ b/backup/moodle2/backup_zoom_activity_task.class.php
@@ -23,7 +23,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die;
+defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot . '/mod/zoom/backup/moodle2/backup_zoom_stepslib.php');
 

--- a/db/caches.php
+++ b/db/caches.php
@@ -22,7 +22,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die;
+defined('MOODLE_INTERNAL') || die();
 
 $definitions = [
     'zoomid' => [

--- a/db/mobile.php
+++ b/db/mobile.php
@@ -22,7 +22,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die;
+defined('MOODLE_INTERNAL') || die();
 
 $addons = [
     "mod_zoom" => [

--- a/db/services.php
+++ b/db/services.php
@@ -25,7 +25,7 @@
  * @since      Moodle 3.1
  */
 
-defined('MOODLE_INTERNAL') || die;
+defined('MOODLE_INTERNAL') || die();
 
 $functions = [
     'mod_zoom_get_state' => [

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -22,7 +22,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die;
+defined('MOODLE_INTERNAL') || die();
 
 $tasks = [
     [

--- a/settings.php
+++ b/settings.php
@@ -22,155 +22,144 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use core\output\notification;
+use mod_zoom\invitation;
+use mod_zoom\webservice_exception;
+
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->dirroot . '/mod/zoom/locallib.php');
-require_once($CFG->libdir . '/environmentlib.php');
-
-if ($ADMIN->fulltree) {
-    require_once($CFG->dirroot . '/mod/zoom/classes/invitation.php');
-
-    $moodlehashideif = version_compare(normalize_version($CFG->release), '3.7.0', '>=');
-
-    $settings = new admin_settingpage('modsettingzoom', get_string('pluginname', 'mod_zoom'));
+if ($hassiteconfig && $ADMIN->fulltree) {
+    require_once($CFG->dirroot . '/mod/zoom/locallib.php');
 
     // Test whether connection works and display result to user.
     if (!CLI_SCRIPT && $PAGE->url == $CFG->wwwroot . '/' . $CFG->admin . '/settings.php?section=modsettingzoom') {
         $status = 'connectionfailed';
-        $notifyclass = 'notifyproblem';
+        $notifyclass = notification::NOTIFY_ERROR;
         $errormessage = '';
         try {
             zoom_get_user(zoom_get_api_identifier($USER));
             $status = 'connectionok';
-            $notifyclass = 'notifysuccess';
-        } catch (\mod_zoom\webservice_exception $error) {
+            $notifyclass = notification::NOTIFY_SUCCESS;
+        } catch (webservice_exception $error) {
             $errormessage = $error->response;
         } catch (moodle_exception $error) {
             $errormessage = $error->a;
         }
 
-        $statusmessage = $OUTPUT->notification(get_string('connectionstatus', 'mod_zoom') .
-                ': ' . get_string($status, 'mod_zoom') . $errormessage, $notifyclass);
-        $connectionstatus = new admin_setting_heading('zoom/connectionstatus', $statusmessage, '');
-        $settings->add($connectionstatus);
+        $settings->add(new admin_setting_heading(
+            'zoom/connectionstatus',
+            $OUTPUT->notification(
+                get_string('connectionstatus', 'mod_zoom') . ': ' . get_string($status, 'mod_zoom') . $errormessage,
+                $notifyclass
+            ),
+            ''
+        ));
     }
 
     // Connection settings.
     $settings->add(new admin_setting_heading(
         'zoom/connectionsettings',
-        get_string('connectionsettings', 'mod_zoom'),
-        get_string('connectionsettings_desc', 'mod_zoom')
+        new lang_string('connectionsettings', 'mod_zoom'),
+        new lang_string('connectionsettings_desc', 'mod_zoom')
     ));
 
-    $accountid = new admin_setting_configtext(
+    $settings->add(new admin_setting_configtext(
         'zoom/accountid',
-        get_string('accountid', 'mod_zoom'),
-        get_string('accountid_desc', 'mod_zoom'),
+        new lang_string('accountid', 'mod_zoom'),
+        new lang_string('accountid_desc', 'mod_zoom'),
         '',
         PARAM_ALPHANUMEXT
-    );
-    $settings->add($accountid);
+    ));
 
-    $clientid = new admin_setting_configtext(
+    $settings->add(new admin_setting_configtext(
         'zoom/clientid',
-        get_string('clientid', 'mod_zoom'),
-        get_string('clientid_desc', 'mod_zoom'),
+        new lang_string('clientid', 'mod_zoom'),
+        new lang_string('clientid_desc', 'mod_zoom'),
         '',
         PARAM_ALPHANUMEXT
-    );
-    $settings->add($clientid);
+    ));
 
-    $clientsecret = new admin_setting_configpasswordunmask(
+    $settings->add(new admin_setting_configpasswordunmask(
         'zoom/clientsecret',
-        get_string('clientsecret', 'mod_zoom'),
-        get_string('clientsecret_desc', 'mod_zoom'),
+        new lang_string('clientsecret', 'mod_zoom'),
+        new lang_string('clientsecret_desc', 'mod_zoom'),
         ''
-    );
-    $settings->add($clientsecret);
+    ));
 
-    $zoomurl = new admin_setting_configtext(
+    $settings->add(new admin_setting_configtext(
         'zoom/zoomurl',
-        get_string('zoomurl', 'mod_zoom'),
-        get_string('zoomurl_desc', 'mod_zoom'),
+        new lang_string('zoomurl', 'mod_zoom'),
+        new lang_string('zoomurl_desc', 'mod_zoom'),
         '',
         PARAM_URL
-    );
-    $settings->add($zoomurl);
+    ));
 
-    $apiendpointchoices = [
-        ZOOM_API_ENDPOINT_GLOBAL => get_string('apiendpoint_global', 'mod_zoom'),
-        ZOOM_API_ENDPOINT_EU => get_string('apiendpoint_eu', 'mod_zoom'),
-    ];
-    $apiendpoint = new admin_setting_configselect(
+    $settings->add(new admin_setting_configselect(
         'zoom/apiendpoint',
-        get_string('apiendpoint', 'mod_zoom'),
-        get_string('apiendpoint_desc', 'mod_zoom'),
+        new lang_string('apiendpoint', 'mod_zoom'),
+        new lang_string('apiendpoint_desc', 'mod_zoom'),
         ZOOM_API_ENDPOINT_GLOBAL,
-        $apiendpointchoices
-    );
-    $settings->add($apiendpoint);
+        [
+            ZOOM_API_ENDPOINT_GLOBAL => new lang_string('apiendpoint_global', 'mod_zoom'),
+            ZOOM_API_ENDPOINT_EU => new lang_string('apiendpoint_eu', 'mod_zoom'),
+        ]
+    ));
 
-    $proxyhost = new admin_setting_configtext(
+    $settings->add(new admin_setting_configtext(
         'zoom/proxyhost',
-        get_string('option_proxyhost', 'mod_zoom'),
-        get_string('option_proxyhost_desc', 'mod_zoom'),
+        new lang_string('option_proxyhost', 'mod_zoom'),
+        new lang_string('option_proxyhost_desc', 'mod_zoom'),
         '',
         '/^[a-zA-Z0-9.-]+:[0-9]+$|^$/'
-    );
-    $settings->add($proxyhost);
+    ));
 
-    $apiidentifier = new admin_setting_configselect(
+    $settings->add(new admin_setting_configselect(
         'zoom/apiidentifier',
-        get_string('apiidentifier', 'mod_zoom'),
-        get_string('apiidentifier_desc', 'mod_zoom'),
+        new lang_string('apiidentifier', 'mod_zoom'),
+        new lang_string('apiidentifier_desc', 'mod_zoom'),
         'email',
         zoom_get_api_identifier_fields()
-    );
-    $settings->add($apiidentifier);
+    ));
 
     // License settings.
     $settings->add(new admin_setting_heading(
         'zoom/licensesettings',
-        get_string('licensesettings', 'mod_zoom'),
-        get_string('licensesettings_desc', 'mod_zoom')
+        new lang_string('licensesettings', 'mod_zoom'),
+        new lang_string('licensesettings_desc', 'mod_zoom')
     ));
 
-    $licensescount = new admin_setting_configtext(
+    $settings->add(new admin_setting_configtext(
         'zoom/licensesnumber',
-        get_string('licensesnumber', 'mod_zoom'),
+        new lang_string('licensesnumber', 'mod_zoom'),
         null,
         0,
         PARAM_INT
-    );
-    $settings->add($licensescount);
+    ));
 
-    $utmost = new admin_setting_configcheckbox(
+    $settings->add(new admin_setting_configcheckbox(
         'zoom/utmost',
-        get_string('redefinelicenses', 'mod_zoom'),
-        get_string('lowlicenses', 'mod_zoom'),
+        new lang_string('redefinelicenses', 'mod_zoom'),
+        new lang_string('lowlicenses', 'mod_zoom'),
         0,
         1
-    );
-    $settings->add($utmost);
+    ));
 
-    $instanceusers = new admin_setting_configcheckbox(
+    $settings->add(new admin_setting_configcheckbox(
         'zoom/instanceusers',
-        get_string('instanceusers', 'mod_zoom'),
-        get_string('instanceusers_desc', 'mod_zoom'),
+        new lang_string('instanceusers', 'mod_zoom'),
+        new lang_string('instanceusers_desc', 'mod_zoom'),
         0,
         1,
         0
-    );
-    $settings->add($instanceusers);
+    ));
 
-    $recycleonjoin = new admin_setting_configcheckbox(
+    $settings->add(new admin_setting_configcheckbox(
         'zoom/recycleonjoin',
-        get_string('recycleonjoin', 'mod_zoom'),
-        get_string('licenseonjoin', 'mod_zoom'),
+        new lang_string('recycleonjoin', 'mod_zoom'),
+        new lang_string('licenseonjoin', 'mod_zoom'),
         0,
         1
-    );
-    $settings->add($recycleonjoin);
+    ));
 
     // Only call to the web services and load the setting if the connection is OK.
     if (isset($status) && $status === 'connectionok') {
@@ -180,21 +169,20 @@ if ($ADMIN->fulltree) {
             $zoomgroups[$group->id] = $group->name;
         }
 
-        $protectedgroups = new admin_setting_configmultiselect(
+        $settings->add(new admin_setting_configmultiselect(
             'zoom/protectedgroups',
-            get_string('protectedgroups', 'mod_zoom'),
-            get_string('protectedgroups_desc', 'mod_zoom'),
+            new lang_string('protectedgroups', 'mod_zoom'),
+            new lang_string('protectedgroups_desc', 'mod_zoom'),
             [],
             $zoomgroups
-        );
-        $settings->add($protectedgroups);
+        ));
     }
 
     // Global settings.
     $settings->add(new admin_setting_heading(
         'zoom/globalsettings',
-        get_string('globalsettings', 'mod_zoom'),
-        get_string('globalsettings_desc', 'mod_zoom')
+        new lang_string('globalsettings', 'mod_zoom'),
+        new lang_string('globalsettings_desc', 'mod_zoom')
     ));
 
     $jointimechoices = [0, 5, 10, 15, 20, 30, 45, 60];
@@ -203,428 +191,368 @@ if ($ADMIN->fulltree) {
         $jointimeselect[$minutes] = $minutes . ' ' . get_string('mins');
     }
 
-    $firstabletojoin = new admin_setting_configselect(
+    $settings->add(new admin_setting_configselect(
         'zoom/firstabletojoin',
-        get_string('firstjoin', 'mod_zoom'),
-        get_string('firstjoin_desc', 'mod_zoom'),
+        new lang_string('firstjoin', 'mod_zoom'),
+        new lang_string('firstjoin_desc', 'mod_zoom'),
         15,
         $jointimeselect
-    );
-    $settings->add($firstabletojoin);
+    ));
 
-    if ($moodlehashideif) {
-        $displayleadtime = new admin_setting_configcheckbox(
-            'zoom/displayleadtime',
-            get_string('displayleadtime', 'mod_zoom'),
-            get_string('displayleadtime_desc', 'mod_zoom'),
-            0,
-            1,
-            0
-        );
-        $settings->add($displayleadtime);
-        $settings->hide_if('zoom/displayleadtime', 'zoom/firstabletojoin', 'eq', 0);
-    } else {
-        $displayleadtime = new admin_setting_configcheckbox(
-            'zoom/displayleadtime',
-            get_string('displayleadtime', 'mod_zoom'),
-            get_string('displayleadtime_desc', 'mod_zoom') . '<br />' .
-                        get_string('displayleadtime_nohideif', 'mod_zoom', get_string('firstjoin', 'mod_zoom')),
-            0,
-            1,
-            0
-        );
-        $settings->add($displayleadtime);
-    }
-
-    $displaypassword = new admin_setting_configcheckbox(
-        'zoom/displaypassword',
-        get_string('displaypassword', 'mod_zoom'),
-        get_string('displaypassword_help', 'mod_zoom'),
+    $settings->add(new admin_setting_configcheckbox(
+        'zoom/displayleadtime',
+        new lang_string('displayleadtime', 'mod_zoom'),
+        new lang_string('displayleadtime_desc', 'mod_zoom'),
         0,
         1,
         0
-    );
-    $settings->add($displaypassword);
+    ));
+    $settings->hide_if('zoom/displayleadtime', 'zoom/firstabletojoin', 'eq', 0);
 
-    $maskparticipantdata = new admin_setting_configcheckbox(
+    $settings->add(new admin_setting_configcheckbox(
+        'zoom/displaypassword',
+        new lang_string('displaypassword', 'mod_zoom'),
+        new lang_string('displaypassword_help', 'mod_zoom'),
+        0,
+        1,
+        0
+    ));
+
+    $settings->add(new admin_setting_configcheckbox(
         'zoom/maskparticipantdata',
-        get_string('maskparticipantdata', 'mod_zoom'),
-        get_string('maskparticipantdata_help', 'mod_zoom'),
+        new lang_string('maskparticipantdata', 'mod_zoom'),
+        new lang_string('maskparticipantdata_help', 'mod_zoom'),
         0,
         1
-    );
-    $settings->add($maskparticipantdata);
+    ));
 
-    $viewrecordings = new admin_setting_configcheckbox(
+    $settings->add(new admin_setting_configcheckbox(
         'zoom/viewrecordings',
-        get_string('option_view_recordings', 'mod_zoom'),
+        new lang_string('option_view_recordings', 'mod_zoom'),
         '',
         0,
         1,
         0
-    );
-    $settings->add($viewrecordings);
+    ));
 
     // Adding options for the display name using uname parameter in zoom join_url.
-    $options = [
-        'fullname' => get_string('displayfullname', 'mod_zoom'),
-        'firstname' => get_string('displayfirstname', 'mod_zoom'),
-        'idfullname' => get_string('displayidfullname', 'mod_zoom'),
-        'id' => get_string('displayid', 'mod_zoom'),
-    ];
     $settings->add(new admin_setting_configselect(
         'zoom/unamedisplay',
-        get_string('unamedisplay', 'mod_zoom'),
-        get_string('unamedisplay_help', 'mod_zoom'),
+        new lang_string('unamedisplay', 'mod_zoom'),
+        new lang_string('unamedisplay_help', 'mod_zoom'),
         'fullname',
-        $options
+        [
+            'fullname' => new lang_string('displayfullname', 'mod_zoom'),
+            'firstname' => new lang_string('displayfirstname', 'mod_zoom'),
+            'idfullname' => new lang_string('displayidfullname', 'mod_zoom'),
+            'id' => new lang_string('displayid', 'mod_zoom'),
+        ]
     ));
 
     // Supplementary features settings.
     $settings->add(new admin_setting_heading(
         'zoom/supplementaryfeaturessettings',
-        get_string('supplementaryfeaturessettings', 'mod_zoom'),
-        get_string('supplementaryfeaturessettings_desc', 'mod_zoom')
+        new lang_string('supplementaryfeaturessettings', 'mod_zoom'),
+        new lang_string('supplementaryfeaturessettings_desc', 'mod_zoom')
     ));
 
-    $webinarchoices = [
-        ZOOM_WEBINAR_DISABLE => get_string('webinar_disable', 'mod_zoom'),
-        ZOOM_WEBINAR_SHOWONLYIFLICENSE => get_string('webinar_showonlyiflicense', 'mod_zoom'),
-        ZOOM_WEBINAR_ALWAYSSHOW => get_string('webinar_alwaysshow', 'mod_zoom'),
-    ];
-    $offerwebinar = new admin_setting_configselect(
+    $settings->add(new admin_setting_configselect(
         'zoom/showwebinars',
-        get_string('webinar', 'mod_zoom'),
-        get_string('webinar_desc', 'mod_zoom'),
+        new lang_string('webinar', 'mod_zoom'),
+        new lang_string('webinar_desc', 'mod_zoom'),
         ZOOM_WEBINAR_ALWAYSSHOW,
-        $webinarchoices
-    );
-    $settings->add($offerwebinar);
+        [
+            ZOOM_WEBINAR_DISABLE => new lang_string('webinar_disable', 'mod_zoom'),
+            ZOOM_WEBINAR_SHOWONLYIFLICENSE => new lang_string('webinar_showonlyiflicense', 'mod_zoom'),
+            ZOOM_WEBINAR_ALWAYSSHOW => new lang_string('webinar_alwaysshow', 'mod_zoom'),
+        ]
+    ));
 
-    $webinardefault = new admin_setting_configcheckbox(
+    $settings->add(new admin_setting_configcheckbox(
         'zoom/webinardefault',
-        get_string('webinar_by_default', 'mod_zoom'),
-        get_string('webinar_by_default_desc', 'mod_zoom'),
+        new lang_string('webinar_by_default', 'mod_zoom'),
+        new lang_string('webinar_by_default_desc', 'mod_zoom'),
         0,
         1,
         0
-    );
-    $settings->add($webinardefault);
+    ));
 
-    $encryptionchoices = [
-        ZOOM_ENCRYPTION_DISABLE => get_string('encryptiontype_disable', 'mod_zoom'),
-        ZOOM_ENCRYPTION_SHOWONLYIFPOSSIBLE => get_string('encryptiontype_showonlyife2epossible', 'mod_zoom'),
-        ZOOM_ENCRYPTION_ALWAYSSHOW => get_string('encryptiontype_alwaysshow', 'mod_zoom'),
-    ];
-    $offerencryption = new admin_setting_configselect(
+    $settings->add(new admin_setting_configselect(
         'zoom/showencryptiontype',
-        get_string('encryptiontype', 'mod_zoom'),
-        get_string('encryptiontype_desc', 'mod_zoom'),
+        new lang_string('encryptiontype', 'mod_zoom'),
+        new lang_string('encryptiontype_desc', 'mod_zoom'),
         ZOOM_ENCRYPTION_SHOWONLYIFPOSSIBLE,
-        $encryptionchoices
-    );
-    $settings->add($offerencryption);
+        [
+            ZOOM_ENCRYPTION_DISABLE => new lang_string('encryptiontype_disable', 'mod_zoom'),
+            ZOOM_ENCRYPTION_SHOWONLYIFPOSSIBLE => new lang_string('encryptiontype_showonlyife2epossible', 'mod_zoom'),
+            ZOOM_ENCRYPTION_ALWAYSSHOW => new lang_string('encryptiontype_alwaysshow', 'mod_zoom'),
+        ]
+    ));
 
-    $schedulingprivilegechoices = [
-        ZOOM_SCHEDULINGPRIVILEGE_DISABLE => get_string('schedulingprivilege_disable', 'mod_zoom'),
-        ZOOM_SCHEDULINGPRIVILEGE_ENABLE => get_string('schedulingprivilege_enable', 'mod_zoom'),
-    ];
-    $offerschedulingprivilege = new admin_setting_configselect(
+    $settings->add(new admin_setting_configselect(
         'zoom/showschedulingprivilege',
-        get_string('schedulingprivilege', 'mod_zoom'),
-        get_string('schedulingprivilege_desc', 'mod_zoom'),
+        new lang_string('schedulingprivilege', 'mod_zoom'),
+        new lang_string('schedulingprivilege_desc', 'mod_zoom'),
         ZOOM_SCHEDULINGPRIVILEGE_ENABLE,
-        $schedulingprivilegechoices
-    );
-    $settings->add($offerschedulingprivilege);
+        [
+            ZOOM_SCHEDULINGPRIVILEGE_DISABLE => new lang_string('schedulingprivilege_disable', 'mod_zoom'),
+            ZOOM_SCHEDULINGPRIVILEGE_ENABLE => new lang_string('schedulingprivilege_enable', 'mod_zoom'),
+        ]
+    ));
 
-    $alternativehostschoices = [
-        ZOOM_ALTERNATIVEHOSTS_DISABLE => get_string('alternative_hosts_disable', 'mod_zoom'),
-        ZOOM_ALTERNATIVEHOSTS_INPUTFIELD => get_string('alternative_hosts_inputfield', 'mod_zoom'),
-        ZOOM_ALTERNATIVEHOSTS_PICKER => get_string('alternative_hosts_picker', 'mod_zoom'),
-    ];
     $alternativehostsroles = zoom_get_selectable_alternative_hosts_rolestring(context_system::instance());
-    $offeralternativehosts = new admin_setting_configselect(
+    $settings->add(new admin_setting_configselect(
         'zoom/showalternativehosts',
-        get_string('alternative_hosts', 'mod_zoom'),
-        get_string('alternative_hosts_desc', 'mod_zoom', ['roles' => $alternativehostsroles]),
+        new lang_string('alternative_hosts', 'mod_zoom'),
+        new lang_string('alternative_hosts_desc', 'mod_zoom', ['roles' => $alternativehostsroles]),
         ZOOM_ALTERNATIVEHOSTS_INPUTFIELD,
-        $alternativehostschoices
-    );
-    $settings->add($offeralternativehosts);
+        [
+            ZOOM_ALTERNATIVEHOSTS_DISABLE => new lang_string('alternative_hosts_disable', 'mod_zoom'),
+            ZOOM_ALTERNATIVEHOSTS_INPUTFIELD => new lang_string('alternative_hosts_inputfield', 'mod_zoom'),
+            ZOOM_ALTERNATIVEHOSTS_PICKER => new lang_string('alternative_hosts_picker', 'mod_zoom'),
+        ]
+    ));
 
-    $capacitywarningchoices = [
-        ZOOM_CAPACITYWARNING_DISABLE => get_string('meetingcapacitywarning_disable', 'mod_zoom'),
-        ZOOM_CAPACITYWARNING_ENABLE => get_string('meetingcapacitywarning_enable', 'mod_zoom'),
-    ];
-    $offercapacitywarning = new admin_setting_configselect(
+    $settings->add(new admin_setting_configselect(
         'zoom/showcapacitywarning',
-        get_string('meetingcapacitywarning', 'mod_zoom'),
-        get_string('meetingcapacitywarning_desc', 'mod_zoom'),
+        new lang_string('meetingcapacitywarning', 'mod_zoom'),
+        new lang_string('meetingcapacitywarning_desc', 'mod_zoom'),
         ZOOM_CAPACITYWARNING_ENABLE,
-        $capacitywarningchoices
-    );
-    $settings->add($offercapacitywarning);
+        [
+            ZOOM_CAPACITYWARNING_DISABLE => new lang_string('meetingcapacitywarning_disable', 'mod_zoom'),
+            ZOOM_CAPACITYWARNING_ENABLE => new lang_string('meetingcapacitywarning_enable', 'mod_zoom'),
+        ]
+    ));
 
-    $allmeetingschoices = [
-        ZOOM_ALLMEETINGS_DISABLE => get_string('allmeetings_disable', 'mod_zoom'),
-        ZOOM_ALLMEETINGS_ENABLE => get_string('allmeetings_enable', 'mod_zoom'),
-    ];
-    $offerallmeetings = new admin_setting_configselect(
+    $settings->add(new admin_setting_configselect(
         'zoom/showallmeetings',
-        get_string('allmeetings', 'mod_zoom'),
-        get_string('allmeetings_desc', 'mod_zoom'),
+        new lang_string('allmeetings', 'mod_zoom'),
+        new lang_string('allmeetings_desc', 'mod_zoom'),
         ZOOM_ALLMEETINGS_ENABLE,
-        $allmeetingschoices
-    );
-    $settings->add($offerallmeetings);
+        [
+            ZOOM_ALLMEETINGS_DISABLE => new lang_string('allmeetings_disable', 'mod_zoom'),
+            ZOOM_ALLMEETINGS_ENABLE => new lang_string('allmeetings_enable', 'mod_zoom'),
+        ]
+    ));
 
-    $downloadicalchoices = [
-        ZOOM_DOWNLOADICAL_DISABLE => get_string('downloadical_disable', 'mod_zoom'),
-        ZOOM_DOWNLOADICAL_ENABLE => get_string('downloadical_enable', 'mod_zoom'),
-    ];
-    $offerdownloadical = new admin_setting_configselect(
+    $settings->add(new admin_setting_configselect(
         'zoom/showdownloadical',
-        get_string('downloadical', 'mod_zoom'),
-        get_string('downloadical_desc', 'mod_zoom'),
+        new lang_string('downloadical', 'mod_zoom'),
+        new lang_string('downloadical_desc', 'mod_zoom'),
         ZOOM_DOWNLOADICAL_ENABLE,
-        $downloadicalchoices
-    );
-    $settings->add($offerdownloadical);
+        [
+            ZOOM_DOWNLOADICAL_DISABLE => new lang_string('downloadical_disable', 'mod_zoom'),
+            ZOOM_DOWNLOADICAL_ENABLE => new lang_string('downloadical_enable', 'mod_zoom'),
+        ]
+    ));
 
     $sendicalnotificationshelp = get_string('sendicalnotifications_help', 'mod_zoom');
     if (empty($CFG->allowattachments)) {
-        $sendicalnotificationshelp .= '<div class="alert alert-block alert-warning" role="alert">'
-                                      . get_string('sendicalnotifications_warning', 'mod_zoom') . '</div>';
+        $sendicalnotificationshelp .= $OUTPUT->notification(
+            get_string('sendicalnotifications_warning', 'mod_zoom'),
+            notification::NOTIFY_WARNING
+        );
     }
 
-    $sendicalnotifications = new admin_setting_configcheckbox(
+    $settings->add(new admin_setting_configcheckbox(
         'zoom/sendicalnotifications',
-        get_string('sendicalnotifications', 'mod_zoom'),
+        new lang_string('sendicalnotifications', 'mod_zoom'),
         $sendicalnotificationshelp,
         0,
         1,
         0
-    );
-    $settings->add($sendicalnotifications);
+    ));
 
     // Default Zoom settings.
     $settings->add(new admin_setting_heading(
         'zoom/defaultsettings',
-        get_string('defaultsettings', 'mod_zoom'),
-        get_string('defaultsettings_help', 'mod_zoom')
+        new lang_string('defaultsettings', 'mod_zoom'),
+        new lang_string('defaultsettings_help', 'mod_zoom')
     ));
 
-    $defaultrecurring = new admin_setting_configcheckbox(
+    $settings->add(new admin_setting_configcheckbox(
         'zoom/defaultrecurring',
-        get_string('recurringmeeting', 'mod_zoom'),
-        get_string('recurringmeeting_help', 'mod_zoom'),
+        new lang_string('recurringmeeting', 'mod_zoom'),
+        new lang_string('recurringmeeting_help', 'mod_zoom'),
         0,
         1,
         0
-    );
-    $settings->add($defaultrecurring);
+    ));
 
-    $defaultshowschedule = new admin_setting_configcheckbox(
+    $settings->add(new admin_setting_configcheckbox(
         'zoom/defaultshowschedule',
-        get_string('showschedule', 'mod_zoom'),
-        get_string('showschedule_help', 'mod_zoom'),
+        new lang_string('showschedule', 'mod_zoom'),
+        new lang_string('showschedule_help', 'mod_zoom'),
         1,
         1,
         0
-    );
-    $settings->add($defaultshowschedule);
+    ));
 
-    $defaultregistration = new admin_setting_configcheckbox(
+    $settings->add(new admin_setting_configcheckbox(
         'zoom/defaultregistration',
-        get_string('registration', 'mod_zoom'),
-        get_string('registration_help', 'mod_zoom'),
+        new lang_string('registration', 'mod_zoom'),
+        new lang_string('registration_help', 'mod_zoom'),
         ZOOM_REGISTRATION_OFF,
         ZOOM_REGISTRATION_AUTOMATIC,
         ZOOM_REGISTRATION_OFF
-    );
-    $settings->add($defaultregistration);
+    ));
 
-    $defaultrequirepasscode = new admin_setting_configcheckbox(
+    $settings->add(new admin_setting_configcheckbox_with_lock(
         'zoom/requirepasscode',
-        get_string('requirepasscode', 'mod_zoom'),
-        get_string('requirepasscode_help', 'mod_zoom'),
-        1
-    );
-    $defaultrequirepasscode->set_locked_flag_options(admin_setting_flag::ENABLED, true);
-    $settings->add($defaultrequirepasscode);
+        new lang_string('requirepasscode', 'mod_zoom'),
+        new lang_string('requirepasscode_help', 'mod_zoom'),
+        [
+            'value' => 1,
+            'locked' => true,
+        ]
+    ));
 
-    $encryptionchoices = [
-        ZOOM_ENCRYPTION_TYPE_ENHANCED => get_string('option_encryption_type_enhancedencryption', 'mod_zoom'),
-        ZOOM_ENCRYPTION_TYPE_E2EE => get_string('option_encryption_type_endtoendencryption', 'mod_zoom'),
-    ];
-    $defaultencryptiontypeoption = new admin_setting_configselect(
+    $settings->add(new admin_setting_configselect(
         'zoom/defaultencryptiontypeoption',
-        get_string('option_encryption_type', 'mod_zoom'),
-        get_string('option_encryption_type_help', 'mod_zoom'),
+        new lang_string('option_encryption_type', 'mod_zoom'),
+        new lang_string('option_encryption_type_help', 'mod_zoom'),
         ZOOM_ENCRYPTION_TYPE_ENHANCED,
-        $encryptionchoices
-    );
-    $settings->add($defaultencryptiontypeoption);
+        [
+            ZOOM_ENCRYPTION_TYPE_ENHANCED => new lang_string('option_encryption_type_enhancedencryption', 'mod_zoom'),
+            ZOOM_ENCRYPTION_TYPE_E2EE => new lang_string('option_encryption_type_endtoendencryption', 'mod_zoom'),
+        ]
+    ));
 
-    $defaultwaitingroomoption = new admin_setting_configcheckbox(
+    $settings->add(new admin_setting_configcheckbox(
         'zoom/defaultwaitingroomoption',
-        get_string('option_waiting_room', 'mod_zoom'),
-        get_string('option_waiting_room_help', 'mod_zoom'),
+        new lang_string('option_waiting_room', 'mod_zoom'),
+        new lang_string('option_waiting_room_help', 'mod_zoom'),
         1,
         1,
         0
-    );
-    $settings->add($defaultwaitingroomoption);
+    ));
 
-    $defaultjoinbeforehost = new admin_setting_configcheckbox(
+    $settings->add(new admin_setting_configcheckbox(
         'zoom/defaultjoinbeforehost',
-        get_string('option_jbh', 'mod_zoom'),
-        get_string('option_jbh_help', 'mod_zoom'),
+        new lang_string('option_jbh', 'mod_zoom'),
+        new lang_string('option_jbh_help', 'mod_zoom'),
         0,
         1,
         0
-    );
-    $settings->add($defaultjoinbeforehost);
+    ));
 
-    $defaultauthusersoption = new admin_setting_configcheckbox(
+    $settings->add(new admin_setting_configcheckbox(
         'zoom/defaultauthusersoption',
-        get_string('option_authenticated_users', 'mod_zoom'),
-        get_string('option_authenticated_users_help', 'mod_zoom'),
+        new lang_string('option_authenticated_users', 'mod_zoom'),
+        new lang_string('option_authenticated_users_help', 'mod_zoom'),
         0,
         1,
         0
-    );
-    $settings->add($defaultauthusersoption);
+    ));
 
-    $defaultshowsecurity = new admin_setting_configcheckbox(
+    $settings->add(new admin_setting_configcheckbox(
         'zoom/defaultshowsecurity',
-        get_string('showsecurity', 'mod_zoom'),
-        get_string('showsecurity_help', 'mod_zoom'),
+        new lang_string('showsecurity', 'mod_zoom'),
+        new lang_string('showsecurity_help', 'mod_zoom'),
         1,
         1,
         0
-    );
-    $settings->add($defaultshowsecurity);
+    ));
 
-    $defaulthostvideo = new admin_setting_configcheckbox(
+    $settings->add(new admin_setting_configcheckbox(
         'zoom/defaulthostvideo',
-        get_string('option_host_video', 'mod_zoom'),
-        get_string('option_host_video_help', 'mod_zoom'),
+        new lang_string('option_host_video', 'mod_zoom'),
+        new lang_string('option_host_video_help', 'mod_zoom'),
         0,
         1,
         0
-    );
-    $settings->add($defaulthostvideo);
+    ));
 
-    $defaultparticipantsvideo = new admin_setting_configcheckbox(
+    $settings->add(new admin_setting_configcheckbox(
         'zoom/defaultparticipantsvideo',
-        get_string('option_participants_video', 'mod_zoom'),
-        get_string('option_participants_video_help', 'mod_zoom'),
+        new lang_string('option_participants_video', 'mod_zoom'),
+        new lang_string('option_participants_video_help', 'mod_zoom'),
         0,
         1,
         0
-    );
-    $settings->add($defaultparticipantsvideo);
+    ));
 
-    $audiochoices = [
-        ZOOM_AUDIO_TELEPHONY => get_string('audio_telephony', 'mod_zoom'),
-        ZOOM_AUDIO_VOIP => get_string('audio_voip', 'mod_zoom'),
-        ZOOM_AUDIO_BOTH => get_string('audio_both', 'mod_zoom'),
-    ];
-    $defaultaudiooption = new admin_setting_configselect(
+    $settings->add(new admin_setting_configselect(
         'zoom/defaultaudiooption',
-        get_string('option_audio', 'mod_zoom'),
-        get_string('option_audio_help', 'mod_zoom'),
+        new lang_string('option_audio', 'mod_zoom'),
+        new lang_string('option_audio_help', 'mod_zoom'),
         ZOOM_AUDIO_BOTH,
-        $audiochoices
-    );
-    $settings->add($defaultaudiooption);
+        [
+            ZOOM_AUDIO_TELEPHONY => new lang_string('audio_telephony', 'mod_zoom'),
+            ZOOM_AUDIO_VOIP => new lang_string('audio_voip', 'mod_zoom'),
+            ZOOM_AUDIO_BOTH => new lang_string('audio_both', 'mod_zoom'),
+        ]
+    ));
 
-    $defaultmuteuponentryoption = new admin_setting_configcheckbox(
+    $settings->add(new admin_setting_configcheckbox(
         'zoom/defaultmuteuponentryoption',
-        get_string('option_mute_upon_entry', 'mod_zoom'),
-        get_string('option_mute_upon_entry_help', 'mod_zoom'),
+        new lang_string('option_mute_upon_entry', 'mod_zoom'),
+        new lang_string('option_mute_upon_entry_help', 'mod_zoom'),
         1,
         1,
         0
-    );
-    $settings->add($defaultmuteuponentryoption);
+    ));
 
-    $autorecordingchoices = [
-        ZOOM_AUTORECORDING_NONE => get_string('autorecording_none', 'mod_zoom'),
-        ZOOM_AUTORECORDING_USERDEFAULT => get_string('autorecording_userdefault', 'mod_zoom'),
-        ZOOM_AUTORECORDING_LOCAL => get_string('autorecording_local', 'mod_zoom'),
-        ZOOM_AUTORECORDING_CLOUD => get_string('autorecording_cloud', 'mod_zoom'),
-    ];
-    $recordingoption = new admin_setting_configselect(
+    $settings->add(new admin_setting_configselect(
         'zoom/recordingoption',
-        get_string('option_auto_recording', 'mod_zoom'),
-        get_string('option_auto_recording_help', 'mod_zoom'),
+        new lang_string('option_auto_recording', 'mod_zoom'),
+        new lang_string('option_auto_recording_help', 'mod_zoom'),
         ZOOM_AUTORECORDING_USERDEFAULT,
-        $autorecordingchoices
-    );
-    $settings->add($recordingoption);
+        [
+            ZOOM_AUTORECORDING_NONE => new lang_string('autorecording_none', 'mod_zoom'),
+            ZOOM_AUTORECORDING_USERDEFAULT => new lang_string('autorecording_userdefault', 'mod_zoom'),
+            ZOOM_AUTORECORDING_LOCAL => new lang_string('autorecording_local', 'mod_zoom'),
+            ZOOM_AUTORECORDING_CLOUD => new lang_string('autorecording_cloud', 'mod_zoom'),
+        ]
+    ));
 
-    $allowrecordingchangeoption = new admin_setting_configcheckbox(
+    $settings->add(new admin_setting_configcheckbox(
         'zoom/allowrecordingchangeoption',
-        get_string('option_allow_recording_change', 'mod_zoom'),
-        get_string('option_allow_recording_change_help', 'mod_zoom'),
+        new lang_string('option_allow_recording_change', 'mod_zoom'),
+        new lang_string('option_allow_recording_change_help', 'mod_zoom'),
         1,
         1,
         0
-    );
-    $settings->add($allowrecordingchangeoption);
+    ));
 
-    $defaultshowmedia = new admin_setting_configcheckbox(
+    $settings->add(new admin_setting_configcheckbox(
         'zoom/defaultshowmedia',
-        get_string('showmedia', 'mod_zoom'),
-        get_string('showmedia_help', 'mod_zoom'),
+        new lang_string('showmedia', 'mod_zoom'),
+        new lang_string('showmedia_help', 'mod_zoom'),
         1,
         1,
         0
-    );
-    $settings->add($defaultshowmedia);
+    ));
 
     $defaulttrackingfields = new admin_setting_configtextarea(
         'zoom/defaulttrackingfields',
-        get_string('trackingfields', 'mod_zoom'),
-        get_string('trackingfields_help', 'mod_zoom'),
+        new lang_string('trackingfields', 'mod_zoom'),
+        new lang_string('trackingfields_help', 'mod_zoom'),
         ''
     );
     $defaulttrackingfields->set_updatedcallback('mod_zoom_update_tracking_fields');
     $settings->add($defaulttrackingfields);
 
     // Adding setting for pre-assigned breakout rooms.
-    $preassignbreakoutrooms = new admin_setting_configcheckbox(
+    $settings->add(new admin_setting_configcheckbox(
         'zoom/preassignbreakoutrooms',
-        get_string('setting_breakoutroom', 'mod_zoom'),
-        get_string('setting_breakoutroom_help', 'mod_zoom'),
+        new lang_string('setting_breakoutroom', 'mod_zoom'),
+        new lang_string('setting_breakoutroom_help', 'mod_zoom'),
         1,
         1,
         0
-    );
-    $settings->add($preassignbreakoutrooms);
-
-    $invitationregexhelp = get_string('invitationregex_help', 'mod_zoom');
-    if (!$moodlehashideif) {
-        $invitationregexhelp .= "\n\n" . get_string(
-            'invitationregex_nohideif',
-            'mod_zoom',
-            get_string('invitationregexenabled', 'mod_zoom')
-        );
-    }
+    ));
 
     $settings->add(new admin_setting_heading(
         'zoom/invitationregex',
-        get_string('invitationregex', 'mod_zoom'),
-        $invitationregexhelp
+        new lang_string('invitationregex', 'mod_zoom'),
+        new lang_string('invitationregex_help', 'mod_zoom')
     ));
 
     $settings->add(new admin_setting_configcheckbox(
         'zoom/invitationregexenabled',
-        get_string('invitationregexenabled', 'mod_zoom'),
-        get_string('invitationregexenabled_help', 'mod_zoom'),
+        new lang_string('invitationregexenabled', 'mod_zoom'),
+        new lang_string('invitationregexenabled_help', 'mod_zoom'),
         0,
         1,
         0
@@ -632,68 +560,61 @@ if ($ADMIN->fulltree) {
 
     $settings->add(new admin_setting_configcheckbox(
         'zoom/invitationremoveinvite',
-        get_string('invitationremoveinvite', 'mod_zoom'),
-        get_string('invitationremoveinvite_help', 'mod_zoom'),
+        new lang_string('invitationremoveinvite', 'mod_zoom'),
+        new lang_string('invitationremoveinvite_help', 'mod_zoom'),
         0,
         1,
         0
     ));
-    if ($moodlehashideif) {
-        $settings->hide_if('zoom/invitationremoveinvite', 'zoom/invitationregexenabled', 'eq', 0);
-    }
+    $settings->hide_if('zoom/invitationremoveinvite', 'zoom/invitationregexenabled', 'eq', 0);
 
     $settings->add(new admin_setting_configcheckbox(
         'zoom/invitationremoveicallink',
-        get_string('invitationremoveicallink', 'mod_zoom'),
-        get_string('invitationremoveicallink_help', 'mod_zoom'),
+        new lang_string('invitationremoveicallink', 'mod_zoom'),
+        new lang_string('invitationremoveicallink_help', 'mod_zoom'),
         0,
         1,
         0
     ));
-    if ($moodlehashideif) {
-        $settings->hide_if('zoom/invitationremoveicallink', 'zoom/invitationregexenabled', 'eq', 0);
-    }
+    $settings->hide_if('zoom/invitationremoveicallink', 'zoom/invitationregexenabled', 'eq', 0);
 
     // Allow admin to modify regex for invitation parts if zoom api changes.
-    foreach (\mod_zoom\invitation::get_default_invitation_regex() as $element => $pattern) {
-        $name = 'zoom/' . \mod_zoom\invitation::PREFIX . $element;
-        $visiblename = get_string(\mod_zoom\invitation::PREFIX . $element, 'mod_zoom');
-        $description = get_string(\mod_zoom\invitation::PREFIX . $element . '_help', 'mod_zoom');
-        $settings->add(new admin_setting_configtext($name, $visiblename, $description, $pattern));
-        if ($moodlehashideif) {
-            $settings->hide_if(
-                'zoom/' . \mod_zoom\invitation::PREFIX . $element,
-                'zoom/invitationregexenabled',
-                'eq',
-                0
-            );
-        }
+    foreach (invitation::get_default_invitation_regex() as $element => $pattern) {
+        $settings->add(new admin_setting_configtext(
+            'zoom/' . invitation::PREFIX . $element,
+            new lang_string(invitation::PREFIX . $element, 'mod_zoom'),
+            new lang_string(invitation::PREFIX . $element . '_help', 'mod_zoom'),
+            $pattern
+        ));
+        $settings->hide_if(
+            'zoom/' . invitation::PREFIX . $element,
+            'zoom/invitationregexenabled',
+            'eq',
+            0
+        );
     }
 
     // Extra hideif for elements which can be enabled / disabled individually.
-    if ($moodlehashideif) {
-        $settings->hide_if('zoom/invitation_invite', 'zoom/invitationremoveinvite', 'eq', 0);
-        $settings->hide_if('zoom/invitation_icallink', 'zoom/invitationremoveicallink', 'eq', 0);
-    }
+    $settings->hide_if('zoom/invitation_invite', 'zoom/invitationremoveinvite', 'eq', 0);
+    $settings->hide_if('zoom/invitation_icallink', 'zoom/invitationremoveicallink', 'eq', 0);
 
     // Adding options for grading methods.
     $settings->add(new admin_setting_heading(
         'zoom/gradingmethod',
-        get_string('gradingmethod_heading', 'mod_zoom'),
-        get_string('gradingmethod_heading_help', 'mod_zoom')
+        new lang_string('gradingmethod_heading', 'mod_zoom'),
+        new lang_string('gradingmethod_heading_help', 'mod_zoom')
     ));
 
-    // Grading method upon entry: the user gets the full score when clicking to join the session through Moodle.
-    // Grading method upon period: the user is graded based on how long they attended the actual session.
-    $options = [
-        'entry' => get_string('gradingentry', 'mod_zoom'),
-        'period' => get_string('gradingperiod', 'mod_zoom'),
-    ];
     $settings->add(new admin_setting_configselect(
         'zoom/gradingmethod',
-        get_string('gradingmethod', 'mod_zoom'),
-        get_string('gradingmethod_help', 'mod_zoom'),
+        new lang_string('gradingmethod', 'mod_zoom'),
+        new lang_string('gradingmethod_help', 'mod_zoom'),
         'entry',
-        $options
+        [
+             // The user gets the full score when clicking to join the session through Moodle.
+            'entry' => new lang_string('gradingentry', 'mod_zoom'),
+             // The user is graded based on how long they attended the actual session.
+            'period' => new lang_string('gradingperiod', 'mod_zoom'),
+        ]
     ));
 }

--- a/settings.php
+++ b/settings.php
@@ -50,7 +50,8 @@ if ($hassiteconfig && $ADMIN->fulltree) {
             'zoom/connectionstatus',
             $OUTPUT->notification(
                 get_string('connectionstatus', 'mod_zoom') . ': ' . get_string($status, 'mod_zoom') . $errormessage,
-                $notifyclass
+                $notifyclass,
+                false
             ),
             ''
         ));
@@ -350,7 +351,8 @@ if ($hassiteconfig && $ADMIN->fulltree) {
     if (empty($CFG->allowattachments)) {
         $sendicalnotificationshelp .= $OUTPUT->notification(
             get_string('sendicalnotifications_warning', 'mod_zoom'),
-            notification::NOTIFY_WARNING
+            notification::NOTIFY_WARNING,
+            false
         );
     }
 

--- a/settings.php
+++ b/settings.php
@@ -32,7 +32,7 @@ if ($hassiteconfig && $ADMIN->fulltree) {
     require_once($CFG->dirroot . '/mod/zoom/locallib.php');
 
     // Test whether connection works and display result to user.
-    if (!CLI_SCRIPT && $PAGE->url == $CFG->wwwroot . '/' . $CFG->admin . '/settings.php?section=modsettingzoom') {
+    if (!CLI_SCRIPT && $PAGE->url == $CFG->wwwroot . '/' . $CFG->admin . '/settings.php?section=' . $settings->name) {
         $status = 'connectionfailed';
         $notifyclass = notification::NOTIFY_ERROR;
         $errormessage = '';


### PR DESCRIPTION
Cleanups:

- `$moodlehashideif` is always `true` because this plugin already requires Moodle 3.7+.
  - Remove "false" branches and tidy.
  - Remove `environmentlib.php` because we no longer use `normalize_version()`.
- Use notification constants instead of static strings. Requires Moodle 3.1.
- Use `new lang_string()` when not immediately using the string. Requires Moodle 2.3.
- Use admin_setting_configcheckbox_with_lock for locked fields. Requires Moodle 2.0.
- Avoid creating unnecessary local variables.

Notes:

- "use" statements are completely ignored until the code that needs them is run. So every version of PHP that supports "use" statements (5.3 and newer) can have a reference like `use fakenamespace\fakeclass;` and the code will work just fine (because it ignores references until they are needed).
- `$hassiteconfig` offers a small amount of defense-in-depth. It's checked before the file is included, but just in case!
- While it will probably always be safe to use the `modsettingzoom` page name, because `plugininfo_mod` (and `admin/settings/plugins.php` before that) provide us with an appropriately instantiated `admin_settingpage`, we should not create our own and should use the name attribute that the class provides and uses as the official section name. One less thing to cause a problem if Moodle were to decide to move all plugins into a single folder.
- I didn't modify the MOODLE_INTERNAL guard in `classes/external.php`, because that will be resolved when #673 is merged.