### PR TITLE
fix: remove deprecated FEATURE_GROUPMEMBERSONLY from zoom_supports()

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -48,7 +48,6 @@ function zoom_supports($feature) {
         case FEATURE_COMPLETION_TRACKS_VIEWS:
         case FEATURE_GRADE_HAS_GRADE:
         case FEATURE_GROUPINGS:
-        case FEATURE_GROUPMEMBERSONLY:
         case FEATURE_MOD_INTRO:
         case FEATURE_SHOW_DESCRIPTION:
             return true;


### PR DESCRIPTION
## Summary

Removes `case FEATURE_GROUPMEMBERSONLY:` from `zoom_supports()` in `lib.php`.

Fixes #714

## Problem

The `FEATURE_GROUPMEMBERSONLY` constant has been deprecated in Moodle 5.3 ([MDL-83231](https://tracker.moodle.org/browse/MDL-83231)). In Moodle 5.3+, the upgrade process throws a `plugin_defective_exception` if a module's `_supports()` function returns `true` for `'groupmembersonly'`, rendering the plugin broken and blocking upgrades.

## Change

One line removed from `zoom_supports()` in `lib.php`:

```diff
-        case FEATURE_GROUPMEMBERSONLY:
```

Note: `FEATURE_GROUPINGS` is **not** deprecated and is unchanged.

## Moodle versions affected

Moodle 5.3+ (main branch)