### PR TITLE
lib: events are visible when the module is visible to the user

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -1365,3 +1365,34 @@ function zoom_cm_info_dynamic(cm_info $cm) {
 function zoom_apply_filter_on_meeting_name($name, $options) {
     return substr(format_string($name, true, $options + ['escape' => false]), 0, 200);
 }
+
+/**
+ * Checks whether a given calendar event should be visible to the user.
+ *
+ * @param calendar_event $event The calendar event object.
+ * @param ?int $userid User ID.
+ * @return bool True if visible, false otherwise.
+ */
+function mod_zoom_core_calendar_is_event_visible(calendar_event $event, $userid = null) {
+    global $USER;
+
+    // Only check our events.
+    if (empty($event->instance) || $event->modulename !== 'zoom') {
+        return false;
+    }
+
+    try {
+        $modinfo = get_fast_modinfo($event->courseid, $userid ?? $USER->id);
+        $cm = $modinfo->instances['zoom'][$event->instance] ?? null;
+
+        if (empty($cm)) {
+            return false;
+        }
+
+        // Return the user's visibility for the module.
+        return $cm->uservisible;
+    } catch (\moodle_exception $e) {
+        // Hide the event if the activity module does not exist.
+        return false;
+    }
+}


### PR DESCRIPTION
I saw the suggestion in #716 that we should be implementing `course_calendar_is_event_visible`. The part that I don't understand is why Moodle doesn't run a generic version of this code itself. Maybe some events are intended to be visible to everyone? Please double check that this actually does the right thing. It seems correct, perhaps a bit overly safe, but I'd rather start with safe. Feel free to suggest changes of course.

Fixes #716