### PR TITLE
Add Moodle Playground demo (blueprint + README badge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,21 @@
 plugin offers tight integration with Moodle, supporting meeting creation,
 synchronization, grading and backup/restore.
 
+
+## Try in Moodle Playground
+
+Click the badge below to open this plugin instantly in
+[Moodle Playground](https://moodle-playground.com) — a full Moodle site
+running in the browser, with no local install. The demo includes a course
+with a stub Zoom activity so you can preview the activity view, the
+mod_form, and the plugin's admin settings.
+
+**Note:** the Zoom REST API is not reachable from the Playground sandbox.
+The Join / Start buttons will not work and you cannot create real meetings —
+this preview is intended for UI and admin-settings inspection only.
+
+<a href="https://moodle-playground.com/?blueprint-url=https://raw.githubusercontent.com/jrchamp/moodle-mod_zoom/refs/heads/main/blueprint.json" target="_blank" rel="noopener"><img src="https://raw.githubusercontent.com/ateeducacion/action-moodle-playground-pr-preview/refs/heads/main/assets/playground-preview-button.svg" alt="Preview in Moodle Playground" width="200"></a>
+
 ## Prerequisites
 
 This plugin is designed for Educational or Business Zoom accounts.

--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ synchronization, grading and backup/restore.
 ## Try in Moodle Playground
 
 Click the badge below to open this plugin instantly in
-[Moodle Playground](https://moodle-playground.com) — a full Moodle site
+[Moodle Playground](https://ateeducacion.github.io/moodle-playground/) — a full Moodle site
 running in the browser, with no local install. The demo includes a course
 with a stub Zoom activity so you can preview the activity view, the
 mod_form, and the plugin's admin settings.
 
-**Note:** the Zoom REST API is not reachable from the Playground sandbox.
-The Join / Start buttons will not work and you cannot create real meetings —
+**Note:** This demo uses placeholder Zoom credentials, so real Zoom meetings
+cannot be created or joined. The Join / Start buttons will not work —
 this preview is intended for UI and admin-settings inspection only.
 
-<a href="https://moodle-playground.com/?blueprint-url=https://raw.githubusercontent.com/jrchamp/moodle-mod_zoom/refs/heads/main/blueprint.json" target="_blank" rel="noopener"><img src="https://raw.githubusercontent.com/ateeducacion/action-moodle-playground-pr-preview/refs/heads/main/assets/playground-preview-button.svg" alt="Preview in Moodle Playground" width="200"></a>
+<a href="https://ateeducacion.github.io/moodle-playground/?blueprint-url=https://raw.githubusercontent.com/jrchamp/moodle-mod_zoom/refs/heads/main/blueprint.json" target="_blank" rel="noopener"><img src="https://raw.githubusercontent.com/ateeducacion/action-moodle-playground-pr-preview/refs/heads/main/assets/playground-preview-button.svg" alt="Preview in Moodle Playground" width="200"></a>
 
 ## Prerequisites
 

--- a/blueprint.json
+++ b/blueprint.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ateeducacion/moodle-playground/refs/heads/main/assets/blueprints/blueprint-schema.json",
+  "preferredVersions": {
+    "php": "8.3",
+    "moodle": "5.2"
+  },
+  "landingPage": "/course/view.php?id=2",
+  "constants": {
+    "ADMIN_USER": "admin",
+    "ADMIN_PASS": "test",
+    "ADMIN_EMAIL": "admin@example.com"
+  },
+  "steps": [
+    {
+      "step": "installMoodle",
+      "options": {
+        "adminUser": "{{ADMIN_USER}}",
+        "adminPass": "{{ADMIN_PASS}}",
+        "adminEmail": "{{ADMIN_EMAIL}}",
+        "siteName": "Zoom Activity Demo",
+        "locale": "en",
+        "timezone": "Europe/Madrid"
+      }
+    },
+    {
+      "step": "login",
+      "username": "{{ADMIN_USER}}"
+    },
+    {
+      "step": "installMoodlePlugin",
+      "pluginType": "mod",
+      "pluginName": "zoom",
+      "url": "https://github.com/ncstate-delta/moodle-mod_zoom/archive/refs/heads/main.zip"
+    },
+    {
+      "step": "setConfigs",
+      "configs": [
+        { "plugin": "mod_zoom", "name": "accountid", "value": "PLAYGROUND_DEMO" },
+        { "plugin": "mod_zoom", "name": "clientid", "value": "PLAYGROUND_DEMO" },
+        { "plugin": "mod_zoom", "name": "clientsecret", "value": "PLAYGROUND_DEMO" }
+      ]
+    },
+    {
+      "step": "createCategory",
+      "name": "Test Courses"
+    },
+    {
+      "step": "createCourse",
+      "fullname": "Zoom Activity Demo Course",
+      "shortname": "ZOOMDEMO01",
+      "category": "Test Courses",
+      "summary": "Demo course for the mod_zoom activity module. A stub Zoom meeting activity is preloaded so you can inspect the activity page, the mod_form, and the plugin's admin settings. NOTE: the Zoom REST API is not reachable from the Playground sandbox, so creating, updating or joining real meetings will not work — this preview is intended for UI and settings inspection only.",
+      "format": "topics",
+      "numsections": 3
+    },
+    {
+      "step": "createUser",
+      "username": "student",
+      "password": "test",
+      "email": "student@example.com",
+      "firstname": "Demo",
+      "lastname": "Student"
+    },
+    {
+      "step": "enrolUser",
+      "username": "{{ADMIN_USER}}",
+      "course": "ZOOMDEMO01",
+      "role": "editingteacher"
+    },
+    {
+      "step": "enrolUser",
+      "username": "student",
+      "course": "ZOOMDEMO01",
+      "role": "student"
+    },
+    {
+      "step": "runPhpCode",
+      "code": "if (!defined('CLI_SCRIPT')) { define('CLI_SCRIPT', true); }\nrequire('/www/moodle/config.php');\nrequire_once($CFG->dirroot . '/course/lib.php');\ntry {\n    $course = $DB->get_record('course', ['shortname' => 'ZOOMDEMO01'], '*', MUST_EXIST);\n    $module = $DB->get_record('modules', ['name' => 'zoom'], '*', MUST_EXIST);\n    $admin = get_admin();\n    \\core\\session\\manager::set_user($admin);\n    $now = time();\n    $zoom = (object)[\n        'course'        => $course->id,\n        'name'          => 'Sample Zoom meeting (stub)',\n        'intro'         => '<p>This is a <strong>stub</strong> Zoom activity created directly in the database so you can preview <code>mod_zoom</code>\\'s UI inside Moodle Playground.</p><p>The Zoom REST API is not reachable from the sandbox, so the Join / Start buttons will not work — open the activity to inspect the view page layout, or edit it to inspect the mod_form.</p>',\n        'introformat'   => FORMAT_HTML,\n        'grade'         => 100,\n        'meeting_id'    => 1234567890,\n        'host_id'       => 'PLAYGROUND_DEMO_HOST',\n        'created_at'    => gmdate('Y-m-d\\\\TH:i:s\\\\Z', $now),\n        'start_time'    => $now + 3600,\n        'duration'      => 3600,\n        'timezone'      => 'Europe/Madrid',\n        'webinar'       => 0,\n        'recurring'     => 0,\n        'timemodified'  => $now,\n        'exists_on_zoom'=> 0,\n    ];\n    $zoomid = $DB->insert_record('zoom', $zoom);\n    $cm = (object)[\n        'course'       => $course->id,\n        'module'       => $module->id,\n        'instance'     => $zoomid,\n        'section'      => 1,\n        'idnumber'     => '',\n        'added'        => $now,\n        'score'        => 0,\n        'indent'       => 0,\n        'visible'      => 1,\n        'visibleold'   => 1,\n        'groupmode'    => 0,\n        'groupingid'   => 0,\n        'completion'   => 0,\n        'showdescription' => 0,\n    ];\n    $cmid = add_course_module($cm);\n    $DB->set_field('course_modules', 'instance', $zoomid, ['id' => $cmid]);\n    course_add_cm_to_section($course->id, $cmid, 1);\n    rebuild_course_cache($course->id, true);\n    echo \"Created mod_zoom instance id={$zoomid} cmid={$cmid} in course {$course->shortname}\\n\";\n} catch (\\Throwable $e) {\n    echo 'ERROR: ' . $e->getMessage() . \"\\n\";\n}"
+    },
+    {
+      "step": "setLandingPage",
+      "path": "/course/view.php?id=2"
+    }
+  ]
+}

--- a/blueprint.json
+++ b/blueprint.json
@@ -18,8 +18,7 @@
         "adminPass": "{{ADMIN_PASS}}",
         "adminEmail": "{{ADMIN_EMAIL}}",
         "siteName": "Zoom Activity Demo",
-        "locale": "en",
-        "timezone": "Europe/Madrid"
+        "locale": "en"
       }
     },
     {
@@ -30,7 +29,7 @@
       "step": "installMoodlePlugin",
       "pluginType": "mod",
       "pluginName": "zoom",
-      "url": "https://github.com/ncstate-delta/moodle-mod_zoom/archive/refs/heads/main.zip"
+      "url": "https://github.com/jrchamp/moodle-mod_zoom/archive/refs/heads/main.zip"
     },
     {
       "step": "setConfigs",
@@ -49,7 +48,7 @@
       "fullname": "Zoom Activity Demo Course",
       "shortname": "ZOOMDEMO01",
       "category": "Test Courses",
-      "summary": "Demo course for the mod_zoom activity module. A stub Zoom meeting activity is preloaded so you can inspect the activity page, the mod_form, and the plugin's admin settings. NOTE: the Zoom REST API is not reachable from the Playground sandbox, so creating, updating or joining real meetings will not work — this preview is intended for UI and settings inspection only.",
+      "summary": "Demo course for the mod_zoom activity module. A stub Zoom meeting activity is preloaded so you can inspect the activity page, the mod_form, and the plugin's admin settings. NOTE: this demo uses placeholder Zoom credentials, so real Zoom meetings cannot be created or joined — this preview is intended for UI and settings inspection only.",
       "format": "topics",
       "numsections": 3
     },
@@ -75,7 +74,7 @@
     },
     {
       "step": "runPhpCode",
-      "code": "if (!defined('CLI_SCRIPT')) { define('CLI_SCRIPT', true); }\nrequire('/www/moodle/config.php');\nrequire_once($CFG->dirroot . '/course/lib.php');\ntry {\n    $course = $DB->get_record('course', ['shortname' => 'ZOOMDEMO01'], '*', MUST_EXIST);\n    $module = $DB->get_record('modules', ['name' => 'zoom'], '*', MUST_EXIST);\n    $admin = get_admin();\n    \\core\\session\\manager::set_user($admin);\n    $now = time();\n    $zoom = (object)[\n        'course'        => $course->id,\n        'name'          => 'Sample Zoom meeting (stub)',\n        'intro'         => '<p>This is a <strong>stub</strong> Zoom activity created directly in the database so you can preview <code>mod_zoom</code>\\'s UI inside Moodle Playground.</p><p>The Zoom REST API is not reachable from the sandbox, so the Join / Start buttons will not work — open the activity to inspect the view page layout, or edit it to inspect the mod_form.</p>',\n        'introformat'   => FORMAT_HTML,\n        'grade'         => 100,\n        'meeting_id'    => 1234567890,\n        'host_id'       => 'PLAYGROUND_DEMO_HOST',\n        'created_at'    => gmdate('Y-m-d\\\\TH:i:s\\\\Z', $now),\n        'start_time'    => $now + 3600,\n        'duration'      => 3600,\n        'timezone'      => 'Europe/Madrid',\n        'webinar'       => 0,\n        'recurring'     => 0,\n        'timemodified'  => $now,\n        'exists_on_zoom'=> 0,\n    ];\n    $zoomid = $DB->insert_record('zoom', $zoom);\n    $cm = (object)[\n        'course'       => $course->id,\n        'module'       => $module->id,\n        'instance'     => $zoomid,\n        'section'      => 1,\n        'idnumber'     => '',\n        'added'        => $now,\n        'score'        => 0,\n        'indent'       => 0,\n        'visible'      => 1,\n        'visibleold'   => 1,\n        'groupmode'    => 0,\n        'groupingid'   => 0,\n        'completion'   => 0,\n        'showdescription' => 0,\n    ];\n    $cmid = add_course_module($cm);\n    $DB->set_field('course_modules', 'instance', $zoomid, ['id' => $cmid]);\n    course_add_cm_to_section($course->id, $cmid, 1);\n    rebuild_course_cache($course->id, true);\n    echo \"Created mod_zoom instance id={$zoomid} cmid={$cmid} in course {$course->shortname}\\n\";\n} catch (\\Throwable $e) {\n    echo 'ERROR: ' . $e->getMessage() . \"\\n\";\n}"
+      "code": "if (!defined('CLI_SCRIPT')) { define('CLI_SCRIPT', true); }\nrequire('/www/moodle/config.php');\nrequire_once($CFG->dirroot . '/course/lib.php');\ntry {\n    $course = $DB->get_record('course', ['shortname' => 'ZOOMDEMO01'], '*', MUST_EXIST);\n    $module = $DB->get_record('modules', ['name' => 'zoom'], '*', MUST_EXIST);\n    $admin = get_admin();\n    \\core\\session\\manager::set_user($admin);\n    $now = time();\n    $zoom = (object)[\n        'course'        => $course->id,\n        'name'          => 'Sample Zoom meeting (stub)',\n        'intro'         => '<p>This is a <strong>stub</strong> Zoom activity created directly in the database so you can preview <code>mod_zoom</code>\\'s UI inside Moodle Playground.</p><p>This demo uses placeholder Zoom credentials, so real Zoom meetings cannot be created or joined — open the activity to inspect the view page layout, or edit it to inspect the mod_form.</p>',\n        'introformat'   => FORMAT_HTML,\n        'grade'         => 100,\n        'meeting_id'    => 1234567890,\n        'host_id'       => 'PLAYGROUND_DEMO_HOST',\n        'created_at'    => gmdate('Y-m-d\\\\TH:i:s\\\\Z', $now),\n        'start_time'    => $now + 3600,\n        'duration'      => 3600,\n        'timezone'      => 'UTC',\n        'webinar'       => 0,\n        'recurring'     => 0,\n        'timemodified'  => $now,\n        'exists_on_zoom'=> 0,\n    ];\n    $zoomid = $DB->insert_record('zoom', $zoom);\n    $cm = (object)[\n        'course'       => $course->id,\n        'module'       => $module->id,\n        'instance'     => $zoomid,\n        'section'      => 1,\n        'idnumber'     => '',\n        'added'        => $now,\n        'score'        => 0,\n        'indent'       => 0,\n        'visible'      => 1,\n        'visibleold'   => 1,\n        'groupmode'    => 0,\n        'groupingid'   => 0,\n        'completion'   => 0,\n        'showdescription' => 0,\n    ];\n    $cmid = add_course_module($cm);\n    $DB->set_field('course_modules', 'instance', $zoomid, ['id' => $cmid]);\n    course_add_cm_to_section($course->id, $cmid, 1);\n    rebuild_course_cache($course->id, true);\n    echo \"Created mod_zoom instance id={$zoomid} cmid={$cmid} in course {$course->shortname}\\n\";\n} catch (\\Throwable $e) {\n    echo 'ERROR: ' . $e->getMessage() . \"\\n\";\n}"
     },
     {
       "step": "setLandingPage",


### PR DESCRIPTION
## About this PR — Moodle Playground

[Moodle Playground](https://ateeducacion.github.io/moodle-playground/) ([source](https://github.com/ateeducacion/moodle-playground)) runs a full Moodle site entirely in the browser (PHP + SQLite via WebAssembly). A `blueprint.json` describes how to provision plugins, users, courses and sample content so anyone can try a plugin with one click — no Docker, no local Moodle.

## Update (simplification)

An earlier version of this PR also added a GitHub Action (`.github/workflows/pr-playground-preview.yml`) that automatically attached a Playground preview link to every same-repo pull request.

After reflecting on feedback from similar contributions, I have **removed the workflow**. Requiring `pull-requests: write` and running extra CI on every PR is more than many plugin repositories need, and it can feel invasive when the main goal is simply “try this plugin online.”

This PR now only adds:

1. **`blueprint.json`** — installs `mod_zoom` from this repository, creates a demo course with a stub Zoom activity, and lands on the course page so reviewers can inspect the activity UI, mod_form and admin settings.
2. **`README.md`** — short “Try in Moodle Playground” section with a badge pointing at **this repository’s** `main/blueprint.json` so it works as soon as this is merged. Existing README content is otherwise unchanged.

**Limitation (documented in the README):** this demo uses placeholder Zoom credentials, so real Zoom meetings cannot be created or joined. The demo is for UI and admin-settings inspection only.

No automated PR previews, no new permissions, no releases clutter.

## Review follow-up

Addressed the review notes:
- demo plugin zip now uses `jrchamp/moodle-mod_zoom`
- no `Europe/Madrid` override; the sample meeting timezone is `UTC`
- Playground links use the GitHub Pages URL directly (`ateeducacion.github.io/moodle-playground`) instead of the convenience `.com` domain

## Try it (preview of the README button)

This is the same button that will appear in the README. Until this PR is merged, the README badge correctly targets the future upstream path (so it works right after merge). The button **below** points at the live blueprint on my fork branch so you can try the demo today:

<a href="https://ateeducacion.github.io/moodle-playground/?blueprint-url=https://raw.githubusercontent.com/erseco/moodle-mod_zoom/refs/heads/feature/moodle-playground-preview/blueprint.json" target="_blank" rel="noopener"><img src="https://raw.githubusercontent.com/ateeducacion/action-moodle-playground-pr-preview/refs/heads/main/assets/playground-preview-button.svg" alt="Preview in Moodle Playground" width="200"></a>

After merge, the README badge will resolve to:

`https://ateeducacion.github.io/moodle-playground/?blueprint-url=https://raw.githubusercontent.com/jrchamp/moodle-mod_zoom/refs/heads/main/blueprint.json`

## Test plan

- [ ] Open the Playground button above and confirm Moodle boots with the plugin installed.
- [ ] Confirm the demo course shows a stub Zoom activity for UI inspection.
- [ ] Confirm this PR does not add any GitHub workflow under `.github/workflows/`.

Happy to adjust the README wording or the demo content if you prefer something even smaller.